### PR TITLE
ci: reset TARGET_EXIT_CODE per target (stop flake cascade)

### DIFF
--- a/.github/workflows/ci-multiplatform.yml
+++ b/.github/workflows/ci-multiplatform.yml
@@ -78,9 +78,9 @@ jobs:
             echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
             echo "Start time: $(date)"
 
+            TARGET_EXIT_CODE=0
             swift test --filter "$target" --enable-code-coverage || TARGET_EXIT_CODE=$?
 
-            TARGET_EXIT_CODE=${TARGET_EXIT_CODE:-0}
             echo "End time: $(date) (exit code: $TARGET_EXIT_CODE)"
 
             if [ $TARGET_EXIT_CODE -eq 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,9 +274,8 @@ jobs:
           echo "Start time: $(date)"
 
           # Run tests (job-level timeout handles hung tests)
+          TARGET_EXIT_CODE=0
           swift test --filter "$target" --enable-code-coverage || TARGET_EXIT_CODE=$?
-
-          TARGET_EXIT_CODE=${TARGET_EXIT_CODE:-0}
           echo "End time: $(date) (exit code: $TARGET_EXIT_CODE)"
 
           if [ $TARGET_EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
## Summary

The per-target test loops in `ci.yml` and `ci-multiplatform.yml` never reset `TARGET_EXIT_CODE` between iterations:

```bash
swift test --filter "$target" ... || TARGET_EXIT_CODE=$?   # only sets on failure
TARGET_EXIT_CODE=${TARGET_EXIT_CODE:-0}                     # only defaults when UNSET
```

Once one target's `swift test` returns non-zero, every subsequent **passing** target inherits the stale value via `${...:-0}` and is reported `❌ failed`. Fix: set `TARGET_EXIT_CODE=0` at the top of each iteration (and drop the redundant `:-0` fallback).

## Why

On the v0.5.0 release PR (#59), a flaky non-zero exit from `PipelineKitSecurityTests` — where **all 109 tests passed** — cascaded into five false target failures (`Security`, `Cache`, `Pooling`, `Observability`, `TestSupport`), failing the `macOS • SwiftPM (Debug + Release)` check. It cleared on re-run.

## Scope

This stops the **cascade**. An individual target's genuinely-flaky `swift test` exit can still fail the job (which is correct). The underlying per-target flake (a `swift test --filter` process returning 1 despite all tests passing) is a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)