### PR TITLE
Fix StatsD sampling no-op for short metric names + deflake SamplingTests

### DIFF
--- a/Sources/PipelineKitObservability/Exporters/StatsDExporter.swift
+++ b/Sources/PipelineKitObservability/Exporters/StatsDExporter.swift
@@ -148,12 +148,19 @@ public actor StatsDExporter: MetricRecorder {
     // MARK: - Sampling Logic
     
     /// Stable hash function for deterministic sampling across program runs.
-    /// Uses DJB2 algorithm - simple, fast, and good distribution.
+    /// DJB2 accumulation followed by a splitmix64 finalizer: raw DJB2 of a
+    /// short string (< ~13 bytes) never wraps UInt64, so its value is tiny
+    /// relative to UInt64.max and `hash / UInt64.max` collapses toward 0 —
+    /// which made rate-based sampling keep everything for typical metric
+    /// names. The finalizer spreads the value uniformly across UInt64.
     nonisolated private func stableHash(_ string: String) -> UInt64 {
         var hash: UInt64 = 5381
         for byte in string.utf8 {
             hash = ((hash &<< 5) &+ hash) &+ UInt64(byte)  // hash * 33 + byte
         }
+        hash = (hash ^ (hash >> 30)) &* 0xBF58476D1CE4E5B9
+        hash = (hash ^ (hash >> 27)) &* 0x94D049BB133111EB
+        hash ^= hash >> 31
         return hash
     }
     

--- a/Tests/PipelineKitObservabilityTests/SamplingTests.swift
+++ b/Tests/PipelineKitObservabilityTests/SamplingTests.swift
@@ -294,11 +294,24 @@ private actor MockSamplingExporter: MetricRecorder {
         let rate = configuration.sampleRatesByType[snapshot.type] ?? configuration.sampleRate
         guard rate < 1.0 else { return (true, 1.0) }
         
-        let hash = snapshot.name.hashValue
-        let threshold = Int(rate * Double(Int.max))
-        let shouldSample = abs(hash) < threshold
-        
+        // Same stable djb2 hash as StatsDExporter.stableHash — String.hashValue
+        // is seeded per process, which made these decisions reshuffle every run.
+        let hash = stableHash(snapshot.name)
+        let normalizedHash = Double(hash) / Double(UInt64.max)
+        let shouldSample = normalizedHash < rate
+
         return (shouldSample, rate)
+    }
+
+    private func stableHash(_ string: String) -> UInt64 {
+        var hash: UInt64 = 5381
+        for byte in string.utf8 {
+            hash = ((hash &<< 5) &+ hash) &+ UInt64(byte)  // hash * 33 + byte
+        }
+        hash = (hash ^ (hash >> 30)) &* 0xBF58476D1CE4E5B9
+        hash = (hash ^ (hash >> 27)) &* 0x94D049BB133111EB
+        hash ^= hash >> 31
+        return hash
     }
 }
 


### PR DESCRIPTION
## Summary

PR #65's CI re-run verification surfaced a flaky `SamplingTests.testPerTypeSampling` failure (`0 is not greater than 0`). Root-causing it uncovered two stacked bugs — one in the test, one real in production:

1. **The flake (test bug)**: `MockSamplingExporter` claimed to replicate `StatsDExporter`'s sampling but used `String.hashValue` — which Swift seeds per process. Sampling decisions reshuffled on every run; ~1-in-500 runs landed all 10 timer names on one side of the threshold. The mock now uses the exporter's actual stable hash.

2. **The production bug (exposed by the fix)**: `StatsDExporter.stableHash` is raw DJB2. For strings under ~13 bytes it never wraps `UInt64`, so for typical metric names (`"timer.3"`, `"api.requests"`) the hash is ~10¹⁵ against `UInt64.max` ≈ 1.8×10¹⁹ — `normalizedHash` collapses to ≈0 and `normalizedHash < rate` is true for any nonzero rate. **Rate-based sampling silently kept everything for short metric names.** Fixed with a splitmix64 finalizer over the DJB2 accumulation: still deterministic and stable across runs, now uniform over `UInt64`.

The old mock (uniform `hashValue`) matched the *intended* semantics, which is exactly why the production degeneracy never showed up in tests.

## Behavior change

Which specific names fall inside a given sampling rate changes (the previous behavior was degenerate, so any fix changes it). Critical-pattern always-keep and rate `0.0`/`1.0` semantics are unchanged.

## Verification

- `SamplingTests`: 9/9, deterministic across repeated runs (previously 3 deterministic failures with the faithful mock, occasional flakes with the seeded one).
- Full `PipelineKitObservabilityTests`: 164 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)