### PR TITLE
Deflake BackPressureMiddlewareTests.testHealthCheck (condition polling)

### DIFF
--- a/Tests/PipelineKitResilienceTests/BackPressureMiddlewareTests.swift
+++ b/Tests/PipelineKitResilienceTests/BackPressureMiddlewareTests.swift
@@ -300,12 +300,15 @@ final class BackPressureMiddlewareTests: XCTestCase {
             }
         }
         
-        // Give time for queue to fill
-        await synchronizer.mediumDelay()
-        
-        // Check health
-        let health = await middleware.healthCheck()
-        
+        // Wait for the queue to fill — poll rather than a single fixed delay so
+        // slow task startup on a loaded runner can't race the health check.
+        var health = await middleware.healthCheck()
+        let deadline = Date().addingTimeInterval(5.0)
+        while health.queueUtilization < 0.8 && Date() < deadline {
+            await synchronizer.shortDelay()
+            health = await middleware.healthCheck()
+        }
+
         // Then
         XCTAssertFalse(health.isHealthy, "Should be unhealthy when queue is > 80% full")
         XCTAssertGreaterThanOrEqual(health.queueUtilization, 0.8)


### PR DESCRIPTION
## Summary

Fourth flaky-test species surfaced by the CI re-run verification (seen failing on #69's run, a PR that doesn't touch Resilience): `testHealthCheck` raced 6 unstructured task startups against one fixed `mediumDelay()`, then asserted queue utilization ≥ 0.8 — a loaded runner got only 3/5 slots filled in time (0.6).

Fix: poll `healthCheck()` until utilization reaches 0.8 with a 5 s deadline (condition-based waiting instead of a fixed sleep). Assertions unchanged. Happy path is faster — the poll exits as soon as the queue fills.

## Verification

5/5 green locally; the wait resolves in ~15 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)