### PR TITLE
Fix lost-wakeup deadlock in SimpleSemaphore cancellation (the CI hang)

### DIFF
--- a/Sources/PipelineKit/Concurrency/SimpleSemaphore.swift
+++ b/Sources/PipelineKit/Concurrency/SimpleSemaphore.swift
@@ -52,14 +52,42 @@ public actor SimpleSemaphore {
         
         // Slow path: wait for a permit with proper cancellation support
         let waiterID = UUID()
-        
-        return try await withTaskCancellationHandler {
+
+        let token = try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 waiters.append((id: waiterID, continuation: continuation))
             }
         } onCancel: {
             Task { await self.cancelWaiter(waiterID) }
         }
+
+        // Cancellation race fix (lost wakeup): `onCancel` merely *spawns* an
+        // unstructured task to run `cancelWaiter`, while a concurrent
+        // `SemaphoreToken.release()` spawns an unstructured task to run
+        // `_release`. Those two tasks race for the actor. If `_release` wins,
+        // it pops this (already-cancelled) waiter and resumes it with a fresh
+        // token, and the later `cancelWaiter` finds nothing to do — so a
+        // cancelled `acquire()` would return a token, violating the documented
+        // contract ("Throws CancellationError if the task is cancelled while
+        // waiting"). Callers that rely on that contract may then strand the
+        // token (e.g. inside a completed `Task`'s result that is never
+        // consumed), trapping the permit forever and deadlocking every future
+        // waiter.
+        //
+        // Detect that outcome here, in the waiter's own task, where the
+        // cancellation flag is unambiguous: if `_release` won the race, the
+        // task's cancel flag was necessarily set *before* `onCancel` fired,
+        // so it is visible by the time we resume. Forward the permit (waking
+        // the next waiter, or restoring a permit) and honor the contract by
+        // throwing. `release()` is idempotent, and the pending `cancelWaiter`
+        // task remains a harmless no-op because `_release` already removed
+        // this waiter. If instead `cancelWaiter` won the race, the
+        // continuation above threw and this code is never reached.
+        if Task.isCancelled {
+            token.release()
+            throw CancellationError()
+        }
+        return token
     }
     
     /// Attempts to acquire a permit without waiting.

--- a/Tests/PipelineKitTests/SimpleSemaphoreCancellationTests.swift
+++ b/Tests/PipelineKitTests/SimpleSemaphoreCancellationTests.swift
@@ -152,7 +152,56 @@ final class SimpleSemaphoreCancellationTests: XCTestCase {
         XCTAssertNotNil(token2)
         token2.release()
     }
-    
+
+    func testCancelledWaiterNeverReceivesToken() async throws {
+        // Regression test for a lost-wakeup deadlock: cancelling a parked
+        // waiter races the token release. `onCancel` spawns a task to run
+        // `cancelWaiter` while `SemaphoreToken.release()` spawns a task to run
+        // `_release`; if `_release` reached the actor first, the cancelled
+        // waiter was resumed with a token and `acquire()` returned success
+        // from a cancelled task. The token could then be stranded (here: in
+        // the completed Task's result storage, which lives until the Task
+        // handle goes away), trapping the permit and hanging every subsequent
+        // acquire — with a fully idle cooperative pool.
+        //
+        // Iterate to exercise both orders of the raced unstructured tasks;
+        // pre-fix the bad order occurred roughly once per ~15 attempts.
+        for iteration in 0..<200 {
+            let semaphore = SimpleSemaphore(permits: 1)
+            let token1 = try await semaphore.acquire()
+
+            let waiter = Task {
+                try await semaphore.acquire()
+            }
+
+            // Deterministically wait until the waiter is parked in the queue.
+            while await semaphore.waitingCount == 0 {
+                await Task.yield()
+            }
+
+            // Race cancellation against release.
+            waiter.cancel()
+            token1.release()
+
+            do {
+                let stray = try await waiter.value
+                // Pre-fix failure mode: release the stray token so this test
+                // fails loudly instead of deadlocking the suite.
+                stray.release()
+                XCTFail("Cancelled waiter received a token (iteration \(iteration))")
+                return
+            } catch is CancellationError {
+                // Expected: a cancelled acquire() must throw.
+            }
+
+            // The permit must be conserved: pre-fix, the bad interleaving
+            // trapped it in `waiter`'s result storage and this acquire
+            // deadlocked forever.
+            let token2 = try await semaphore.acquire()
+            token2.release()
+        }
+    }
+
     func testImmediateCancellation() async throws {
         let semaphore = SimpleSemaphore(permits: 1)
         


### PR DESCRIPTION
## Summary

Root cause of the repo's longest-standing CI mystery — the intermittent test-suite hangs (CI_NOTES' "tests hang" TODO, issue #71, and the historical `--parallel` workaround).

**Bug**: `SimpleSemaphore.acquire()`'s `onCancel` handler only *spawns* a `Task { cancelWaiter() }` — it doesn't cancel synchronously. A concurrent `SemaphoreToken.release()` spawns its own `Task { _release() }`. When the release task reaches the actor first, it pops the already-cancelled waiter and resumes it **with a fresh token**. The cancelled task completes `.success`; the token gets trapped in the completed task's future-result storage (alive as long as the caller holds the task handle); the permit is lost; the next `acquire()` parks forever. Cooperative pool goes fully idle — a textbook lost wakeup (thread-sample and `swift-inspect dump-concurrency` evidence on live hung specimens).

**Why every prior attribution was wrong**: xctest stdout is block-buffered through the swift-test pipe, so a hung run's log trails reality by 1–3 suites. The "last started test" was `PipelineRegistryTests.testCommandTypeCount` in CI (issue #71) and `SimpleCancellationTests` locally — both innocent. Unbuffered stderr markers proved the true hang is always `SimpleSemaphoreCancellationTests.testCancellationDuringRelease` (alphabetically 1–3 suites later). Worth remembering when reading any future hang log.

## Fix

After the continuation resumes with a token, re-check `Task.isCancelled` in the waiter's own task — the only point where the race outcome is unambiguous. If cancelled: `token.release()` (idempotent — forwards the permit to the next waiter or restores it) and `throw CancellationError()`, honoring the documented contract in every interleaving. Uncancelled path unchanged (one atomic load on the slow path). Same style as the v0.5.0 `AsyncSemaphore` TOCTOU fix (`9eb39e9`).

Plus regression test `testCancelledWaiterNeverReceivesToken`: deterministic park (polls `waitingCount`), 200 cancel-vs-release races, asserts throw + permit conservation. **Fails loudly pre-fix** ("Cancelled waiter received a token (iteration 0)") instead of deadlocking.

## Verification

- Repro loop: **70/70 full `PipelineKitTests` target runs clean** (pre-fix: hang at run 11; historical rate ~1/15).
- `PipelineKitTests` 148/148; `PipelineKitResilienceTests` 124 executed, 0 failures.
- Regression suite 10/10 in 0.24 s.

## Known siblings deliberately not fixed here (follow-ups)

- `BackPressureSemaphore.acquire`/`release` (`BackPressureSemaphore.swift:132-147/197-211`): **identical** race pattern; should copy this fix.
- `AsyncSemaphore.wait()`: `signal()` can resume a cancelled waiter normally — contract gap only (no token trapping).
- `BackPressureSemaphore.startCleanupTask()` leaks a background timer task past suite teardown.
- CI_NOTES / issue #71 hang-log attribution guidance (block-buffering hazard).

This also likely explains the historic `swift test --parallel` hangs — same primitive under more concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)