### PR TITLE
fix(resilience): BackPressureSemaphore lost wakeup on cancellation + cleanup-task leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **BackPressureSemaphore lost wakeup on cancellation**: the same race fixed in
+  `SimpleSemaphore` (#73) existed in `BackPressureSemaphore.acquire()` — when a waiter's
+  cancellation raced a token release, the release path could resume the already-cancelled
+  waiter *with* a token, so a cancelled `acquire()` returned success and the permit could
+  be stranded forever. `acquire()` now re-checks cancellation after resuming, forwards the
+  permit, and throws `CancellationError`. Also fixed the cleanup task retaining the actor
+  for the lifetime of its timer loop, which prevented `deinit` from ever running and leaked
+  every semaphore (plus a once-per-second background task) past teardown.
 - **CI Stability**: Root-caused and fixed the flaky test-job failures first seen on the
   v0.5.0 release PR. The genuine failure was a timing race in
   `TimeoutDiagnosticTests.testDirectTimeoutUtility` (a 0.1s timeout racing a 0.2s

--- a/Sources/PipelineKitResilienceFoundation/Semaphore/BackPressureSemaphore.swift
+++ b/Sources/PipelineKitResilienceFoundation/Semaphore/BackPressureSemaphore.swift
@@ -95,7 +95,21 @@ public actor BackPressureSemaphore {
     private func startCleanupTask() {
         if cleanupTask == nil {
             cleanupTask = Task { [weak self] in
-                await self?.runCleanupLoop()
+                // Lifecycle: the strong reference to the actor must be scoped
+                // to each sweep and NEVER held across the sleep. The previous
+                // shape — `await self?.runCleanupLoop()` with the loop inside
+                // an actor method — upgraded the weak capture to a strong one
+                // for the duration of that never-returning call, so the task
+                // retained the actor forever, `deinit` (which cancels this
+                // task) could never run, and every semaphore that ran acquire()
+                // leaked itself plus a once-per-second timer task. With the
+                // loop out here, the actor can deinit while we sleep; deinit
+                // cancels this task, the sleep throws, and the loop exits.
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
+                    guard let self else { return }
+                    await self.cleanupExpiredWaiters()
+                }
             }
         }
     }
@@ -129,7 +143,7 @@ public actor BackPressureSemaphore {
         let waiterID = UUID()
         let enqueuedAt = Date()
 
-        return try await withTaskCancellationHandler {
+        let token = try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 let waiter = Waiter(
                     id: waiterID,
@@ -145,6 +159,34 @@ public actor BackPressureSemaphore {
                 await self?.cancelWaiter(waiterID)
             }
         }
+
+        // Cancellation race fix (lost wakeup), ported from SimpleSemaphore
+        // (PR #73): `onCancel` merely *spawns* an unstructured task to run
+        // `cancelWaiter`, while a concurrent `SemaphoreToken.release()` spawns
+        // an unstructured task to run `release()`. Those two tasks race for the
+        // actor. If `release()` wins, it pops this (already-cancelled) waiter
+        // from the heap and resumes it with a fresh token, and the later
+        // `cancelWaiter` finds nothing to do — so a cancelled `acquire()` would
+        // return a token. Callers that rely on cancellation throwing may then
+        // strand the token (e.g. inside a completed `Task`'s result that is
+        // never consumed), trapping the permit forever and deadlocking every
+        // future waiter.
+        //
+        // Detect that outcome here, in the waiter's own task, where the
+        // cancellation flag is unambiguous: if `release()` won the race, the
+        // task's cancel flag was necessarily set *before* `onCancel` fired, so
+        // it is visible by the time we resume. Forward the permit (waking the
+        // next waiter, or restoring a permit) and honor cancellation by
+        // throwing. `SemaphoreToken.release()` is idempotent, and the pending
+        // `cancelWaiter` task remains a harmless no-op because `release()`
+        // already removed this waiter from the heap. If instead `cancelWaiter`
+        // won the race, the continuation above threw and this code is never
+        // reached.
+        if Task.isCancelled {
+            token.release()
+            throw CancellationError()
+        }
+        return token
     }
     
     /// Attempts to acquire with a timeout.
@@ -289,15 +331,7 @@ public actor BackPressureSemaphore {
     }
     
     // MARK: - Cleanup
-    
-    private func runCleanupLoop() async {
-        while !Task.isCancelled {
-            cleanupExpiredWaiters()
-            
-            try? await Task.sleep(nanoseconds: 1_000_000_000) // 1 second
-        }
-    }
-    
+
     private func cleanupExpiredWaiters() {
         let now = Date()
         // Snapshot the heap (a value-typed array copy) so we can mutate the heap

--- a/Tests/PipelineKitResilienceTests/BackPressureSemaphoreCancellationTests.swift
+++ b/Tests/PipelineKitResilienceTests/BackPressureSemaphoreCancellationTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+// `@testable import` of the internal Foundation target to name `BackPressureSemaphore`
+// directly, following the precedent in `SemaphoreEvolutionTests`.
+@testable import _ResilienceFoundation
+import PipelineKit
+
+/// Regression tests for `BackPressureSemaphore` cancellation races and lifecycle.
+///
+/// Mirrors `SimpleSemaphoreCancellationTests.testCancelledWaiterNeverReceivesToken`
+/// (PR #73): both semaphores share the same waiter-queue + `SemaphoreToken` design
+/// and therefore had the same lost-wakeup bug.
+final class BackPressureSemaphoreCancellationTests: XCTestCase {
+    func testCancelledWaiterNeverReceivesToken() async throws {
+        // Regression test for a lost-wakeup deadlock: cancelling a parked
+        // waiter races the token release. `onCancel` spawns a task to run
+        // `cancelWaiter` while `SemaphoreToken`'s release handler spawns a task
+        // to run `release()`; if `release()` reached the actor first, it popped
+        // the cancelled waiter from the heap and resumed it with a token, so
+        // `acquire()` returned success from a cancelled task. The token could
+        // then be stranded (here: in the completed Task's result storage, which
+        // lives until the Task handle goes away), trapping the permit and
+        // hanging every subsequent acquire — with a fully idle cooperative pool.
+        //
+        // Iterate to exercise both orders of the raced unstructured tasks.
+        for iteration in 0..<200 {
+            let semaphore = BackPressureSemaphore(maxConcurrency: 1)
+            let token1 = try await semaphore.acquire()
+
+            let waiter = Task {
+                try await semaphore.acquire()
+            }
+
+            // Deterministically wait until the waiter is parked in the queue.
+            while await semaphore.getStats().queuedOperations == 0 {
+                await Task.yield()
+            }
+
+            // Race cancellation against release.
+            waiter.cancel()
+            token1.release()
+
+            do {
+                let stray = try await waiter.value
+                // Pre-fix failure mode: release the stray token so this test
+                // fails loudly instead of deadlocking the suite.
+                stray.release()
+                XCTFail("Cancelled waiter received a token (iteration \(iteration))")
+                return
+            } catch is CancellationError {
+                // Expected: a cancelled acquire() must throw.
+            }
+
+            // The permit must be conserved: pre-fix, the bad interleaving
+            // trapped it in `waiter`'s result storage and this acquire
+            // deadlocked forever.
+            let token2 = try await semaphore.acquire()
+            token2.release()
+        }
+    }
+
+    func testCleanupTaskDiesWithSemaphore() async throws {
+        // Regression test for a lifecycle leak: the cleanup task was started as
+        // `Task { [weak self] in await self?.runCleanupLoop() }`. The weak
+        // capture is upgraded to a strong reference for the duration of the
+        // `runCleanupLoop()` call — which is an infinite 1s-timer loop — so the
+        // task retained the actor forever, `deinit` (the only implicit cancel
+        // path) could never run, and every semaphore that ever ran acquire()
+        // leaked itself plus a once-per-second background task past suite
+        // teardown.
+        weak var weakSemaphore: BackPressureSemaphore?
+        do {
+            let semaphore = BackPressureSemaphore(maxConcurrency: 1)
+            weakSemaphore = semaphore
+            // The slow-path machinery is irrelevant here; any acquire() starts
+            // the cleanup task.
+            let token = try await semaphore.acquire()
+            token.release()
+            // Give the spawned cleanup task time to actually enter its loop
+            // before we drop the last reference. If the last reference drops
+            // before the task ever runs, its weak capture resolves to nil and
+            // the leak is masked (the task exits without retaining anything).
+            try await Task.sleep(nanoseconds: 200_000_000)
+        }
+
+        // The token's release handler runs in a detached task holding a weak
+        // reference, so deallocation may trail the scope exit briefly. Poll
+        // with a generous deadline; pre-fix this never becomes nil.
+        let deadline = Date().addingTimeInterval(5)
+        while weakSemaphore != nil && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTAssertNil(
+            weakSemaphore,
+            "Semaphore must deallocate once unreferenced; a live reference means the cleanup task retains the actor and its 1s timer loop outlives the semaphore"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Ports the #73 `SimpleSemaphore` lost-wakeup fix to `BackPressureSemaphore`, which has the identical race, and fixes a cleanup-task lifecycle leak found in the same file. **Production concurrency change — please review before merging.**

## Root cause 1: lost wakeup when release races waiter cancellation

`BackPressureSemaphore.acquire()`'s `onCancel` handler only *spawns* an unstructured task to run `cancelWaiter`, while `SemaphoreToken`'s release handler spawns an unstructured task to run `release()`. The two race for the actor:

1. The only permit is held; a waiter parks in the heap.
2. The waiter's task is cancelled → `onCancel` spawns Task C (`cancelWaiter`).
3. The token is released → its handler spawns Task D (`release()`).
4. **D reaches the actor first**: pops the already-cancelled waiter, resumes it *with a fresh token*; C later finds nothing to remove and no-ops.
5. The cancelled `acquire()` returns success. A caller relying on cancellation throwing (e.g. `try await waiter.value` on a cancelled `Task`) strands the token in the completed task's result storage — the permit is trapped forever and every future waiter deadlocks on an idle cooperative pool.

This is exactly the interleaving root-caused in #73; both semaphores share the waiter-queue + `SemaphoreToken` design. `BulkheadMiddleware`'s task-group + `cancelAll()` acquire path (BulkheadMiddleware.swift:266-270) and `acquire(timeout:)`'s own group are real in-tree consumers of this window.

**Fix** (same shape as #73): after the continuation resumes with a token, re-check `Task.isCancelled` in the waiter's own task — the only point where the race outcome is unambiguous. If cancelled, forward the permit via `token.release()` (idempotent; wakes the next waiter or restores a permit) and throw `CancellationError`. The pending `cancelWaiter` task remains a harmless no-op.

**Pre-fix evidence**: the new regression test fails immediately — `Cancelled waiter received a token (iteration 6)`.

## Root cause 2: cleanup task retains the actor forever

`startCleanupTask()` used `Task { [weak self] in await self?.runCleanupLoop() }`. The weak capture is upgraded to a strong reference **for the duration of the call** — and `runCleanupLoop()` never returns. So the task retained the actor forever, `deinit` (the only implicit cancel path) could never run, and every semaphore that ever ran `acquire()` leaked itself plus a once-per-second timer task past suite teardown.

**Fix**: the loop now lives in the task closure; it sleeps holding only the weak reference and takes a scoped strong reference just for each sweep. The actor can now deinit mid-sleep; `deinit` cancels the task, the sleep throws, the loop exits.

**Pre-fix evidence**: the new deinit regression test shows the actor never deallocates once the loop is on-stack (fails after a 5s poll deadline). Interesting wrinkle: with no delay before dropping the last reference, the leak is *masked* — the cleanup task loses the startup race and its weak capture resolves to nil — which is why the test parks the task in its loop first.

## Regression tests

`BackPressureSemaphoreCancellationTests` (mirrors #73's test shape):
- **testCancelledWaiterNeverReceivesToken** — parks a waiter deterministically (polls `queuedOperations`), races cancel against release, 200 iterations, asserts throw + permit conservation. Releases any stray token so the pre-fix failure is loud, not a hang.
- **testCleanupTaskDiesWithSemaphore** — lets the cleanup task enter its loop, drops the last reference, polls a weak reference to nil with a 5s deadline.

## Verification (all on a clean build)

- Pre-fix: both regression tests fail loudly (shown above).
- Post-fix: **70/70** clean runs of the regression suite.
- Post-fix: full `PipelineKitResilienceTests` target — **126 tests, 0 failures** (4 skipped; was 124 tests before this PR).

## Note for reviewers: stale-artifact segfault during verification

While verifying, an **incremental** `swift build --build-tests` after this change produced a *deterministic* `EXC_BAD_ACCESS` in `SemaphoreEvolutionTests.testBackPressureShutdownDrainsAllWaiters` (`initializeBufferWithCopyOfBuffer for BackPressureSemaphore.Waiter`, garbage metadata pointer). Bisection traced it to *deleting the unused private `runCleanupLoop()` method* — and a clean build (`rm -rf .build`) of the identical source passes 3/3. This is SwiftPM incremental-build artifact skew (the `@testable`-importing test module disagreeing with the library about type layout), not a code path in this diff. If you see that segfault locally, clean-build first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
