### PR TITLE
fix(resilience): AsyncSemaphore cancelled waiter could swallow a signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **AsyncSemaphore could swallow a signal on cancellation**: when a `signal()` raced a
+  parked waiter's cancellation, the cancelled waiter could be resumed as signaled —
+  `wait()` returned normally in a cancelled task (violating its contract) and, because a
+  cancelled caller never signals back, the consumed wakeup was lost and effective
+  capacity shrank by one per occurrence. `wait()` (and `acquire(timeout:)`) now re-check
+  cancellation after resuming, forward the consumed signal to the next waiter, and
+  throw (respectively return `false`). The `wait()` doc now names the error actually
+  thrown on cancellation, `PipelineError.cancelled`.
 - **SimpleSemaphore lost-wakeup deadlock** (#73): when a parked waiter's cancellation
   raced a token release, the release path could resume the already-cancelled waiter
   *with* a token, so a cancelled `acquire()` returned success and the permit could be

--- a/Sources/PipelineKitResilienceFoundation/Semaphore/AsyncSemaphore.swift
+++ b/Sources/PipelineKitResilienceFoundation/Semaphore/AsyncSemaphore.swift
@@ -130,7 +130,11 @@ public actor AsyncSemaphore {
     /// If resources are available (value > 0), this method decrements the count
     /// and returns immediately. Otherwise, it suspends until a resource is released.
     ///
-    /// - Throws: CancellationError if the task is cancelled while waiting
+    /// - Throws: `PipelineError.cancelled` if the task is cancelled while
+    ///   waiting. This holds in every interleaving: if a concurrent `signal()`
+    ///   resumes a waiter whose task was already cancelled, the consumed signal
+    ///   is forwarded to the next waiter (or restored to the count) and the
+    ///   cancelled `wait()` still throws.
     public func wait() async throws {
         // Check for cancellation before proceeding
         try Task.checkCancellation()
@@ -178,8 +182,42 @@ public actor AsyncSemaphore {
                 await self?.handleCancellationForWaiter(waiterId: waiterId)
             }
         }
+
+        // Cancellation race fix (mirror of SimpleSemaphore PR #73 /
+        // BackPressureSemaphore PR #74): `onCancel` above only *spawns* a task
+        // to run `handleCancellationForWaiter`, so a concurrent `signal()` can
+        // reach the actor first, extract this (already-cancelled) waiter from
+        // the heap, and resume it with `.signaled`; the later cancellation
+        // task finds the heap without it and no-ops. Without this re-check, a
+        // cancelled `wait()` would return normally — and since callers pair
+        // every *successful* wait() with a later signal() (and rightly skip
+        // the signal when wait() throws), the wakeup this waiter consumed
+        // would be swallowed: one resource permanently vanishes.
+        //
+        // The re-check runs in the waiter's own task, where the cancellation
+        // flag is unambiguous: if `signal()` won the race, the cancel flag was
+        // set before `onCancel` fired, so it is visible here. Forward the
+        // consumed signal — `signal()` is a synchronous same-actor call that
+        // wakes the next waiter or restores the count, so conservation is
+        // re-established before this method returns — and honor the contract
+        // by throwing the same error as every other cancellation path. All
+        // interleavings:
+        //   - Cancellation task wins: the continuation threw above; this code
+        //     is never reached, and the (awaited) signal restores a resource.
+        //   - signal() wins: resumed .signaled, re-signaled + thrown here; the
+        //     pending cancellation task no-ops (waiter no longer in the heap).
+        //   - Cancelled after resume, before this check: same as signal()
+        //     winning — the resource is forwarded, not double-consumed, and
+        //     the caller sees the throw and does not signal.
+        //   - No cancellation: the flag is false; return normally.
+        // We cannot resume ourselves: this waiter was already extracted, so
+        // the forwarded signal reaches only other waiters or the counter.
+        if Task.isCancelled {
+            signal()
+            throw PipelineError.cancelled(context: "Semaphore wait cancelled")
+        }
     }
-    
+
     /// Waits for a resource to become available with a timeout.
     ///
     /// If resources are available (value > 0), this method decrements the count
@@ -207,7 +245,7 @@ public actor AsyncSemaphore {
         }
         let waiterIdBox = WaiterIdBox()
         
-        return await withTaskCancellationHandler {
+        let acquired = await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                 let waiter = Waiter(seq: nextSeq, continuation: .timeout(continuation))
                 nextSeq &+= 1
@@ -244,6 +282,19 @@ public actor AsyncSemaphore {
                 await self?.handleCancellationForWaiter(waiterId: waiterId)
             }
         }
+
+        // Cancellation race fix: mirrors `wait()` above. If a concurrent
+        // `signal()` beat the spawned cancellation task, this cancelled waiter
+        // was resumed with `.signaled` and `acquired` is true — but the
+        // documented contract is "false if the task was cancelled", and a
+        // caller seeing false will never signal back. Forward the consumed
+        // signal (synchronous same-actor call) and report false. The timeout
+        // task was already cancelled by `signal()` via `cancelTimeout()`.
+        if acquired && Task.isCancelled {
+            signal()
+            return false
+        }
+        return acquired
     }
     
     /// Signals that a resource has been released.

--- a/Tests/PipelineKitResilienceTests/AsyncSemaphoreContractTests.swift
+++ b/Tests/PipelineKitResilienceTests/AsyncSemaphoreContractTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+// `@testable import` of the internal Foundation target to reach the internal
+// `AsyncSemaphore.waiterCount()`, following the precedent in `SemaphoreEvolutionTests`.
+@testable import _ResilienceFoundation
+import PipelineKit
+
+/// Regression tests for the `AsyncSemaphore` cancellation contract:
+/// a cancelled `wait()` must never return normally, and a signal consumed by a
+/// cancelled waiter must be forwarded, not dropped.
+///
+/// Mirrors the race fixed in `SimpleSemaphore` (PR #73) and
+/// `BackPressureSemaphore` (PR #74): `onCancel` only *spawns* a task to run
+/// `handleCancellationForWaiter`, so a concurrent `signal()` can reach the
+/// actor first, pop the already-cancelled waiter from the heap, and resume it
+/// with `.signaled`. No token is involved, so nothing deadlocks — but `wait()`
+/// then returns success from a cancelled task, and the caller (which pairs
+/// every successful `wait()` with a later `signal()`, e.g. `ObjectPool`)
+/// proceeds as if it owns a resource it should have relinquished.
+final class AsyncSemaphoreContractTests: XCTestCase {
+    func testCancelledWaiterDoesNotSwallowSignal() async throws {
+        // Iterate to exercise both orders of the raced work: the spawned
+        // cancellation task vs. the direct signal() call.
+        for iteration in 0..<200 {
+            let semaphore = AsyncSemaphore(value: 0)
+
+            let waiter = Task {
+                try await semaphore.wait()
+            }
+
+            // Deterministically wait until the waiter is parked in the queue.
+            while await semaphore.waiterCount() == 0 {
+                await Task.yield()
+            }
+
+            // Race cancellation against signal.
+            waiter.cancel()
+            await semaphore.signal()
+
+            do {
+                try await waiter.value
+                XCTFail("wait() returned normally in a cancelled task (iteration \(iteration))")
+                return
+            } catch {
+                // Expected: a cancelled wait() must throw
+                // (PipelineError.cancelled, matching the other cancel paths).
+            }
+
+            // Signal conservation: exactly one resource must exist afterwards,
+            // in EITHER order of the race. If cancellation won, the waiter was
+            // resumed as cancelled and the (awaited) signal restored a
+            // resource. If signal won, the cancelled waiter must forward the
+            // consumed signal before throwing — synchronously on the actor,
+            // so it is visible by the time `waiter.value` rethrows. Pre-fix,
+            // the signal-won order swallowed the wakeup (count 0): the
+            // resource vanished into a task that will never signal it back.
+            let resources = await semaphore.availableResourcesCount()
+            XCTAssertEqual(
+                resources, 1,
+                "Signal lost or duplicated after cancel/signal race (iteration \(iteration))"
+            )
+        }
+    }
+
+    func testCancelledTimeoutWaiterDoesNotSwallowSignal() async throws {
+        // Same race through acquire(timeout:), which documents "false if the
+        // task was cancelled". Pre-fix, a signal() that beat the spawned
+        // cancellation task resumed the cancelled waiter with .signaled and
+        // acquire returned true from a cancelled task.
+        for iteration in 0..<200 {
+            let semaphore = AsyncSemaphore(value: 0)
+
+            // Timeout far beyond the race window so it cannot interfere.
+            let waiter = Task {
+                await semaphore.acquire(timeout: 5.0)
+            }
+
+            while await semaphore.waiterCount() == 0 {
+                await Task.yield()
+            }
+
+            waiter.cancel()
+            await semaphore.signal()
+
+            let acquired = await waiter.value
+            XCTAssertFalse(
+                acquired,
+                "acquire(timeout:) returned true in a cancelled task (iteration \(iteration))"
+            )
+            if acquired { return }
+
+            let resources = await semaphore.availableResourcesCount()
+            XCTAssertEqual(
+                resources, 1,
+                "Signal lost or duplicated after cancel/signal race (iteration \(iteration))"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the `AsyncSemaphore.wait()` cancellation contract gap — the third member of the race family fixed in #73 (`SimpleSemaphore`) and #74 (`BackPressureSemaphore`). **Production concurrency change — please review before merging.**

## Root cause

`onCancel` only *spawns* an unstructured task to run `handleCancellationForWaiter`, while a concurrent `signal()` runs directly on the actor. When `signal()` wins, it extracts the already-cancelled waiter from the heap and resumes it with `.signaled`; the later cancellation task finds nothing and no-ops. `wait()` then **returns normally in a cancelled task**, despite its documented contract.

No token is involved, so nothing deadlocks. The damage is subtler — a quiet capacity leak:

- Callers pair every *successful* `wait()` with a later `signal()` and rightly skip the signal when `wait()` throws (e.g. `ObjectPool`: `wait()` in acquire at ObjectPool.swift:135, `signal()` in release at :190).
- A cancelled caller that treats its wait as failed never signals back the wakeup it invisibly consumed → one resource permanently vanishes, shrinking effective capacity by one per occurrence.

`acquire(timeout:)` has the same race against its documented "returns false if the task was cancelled".

## Fix — with the signal-conservation subtlety

Post-resume cancellation re-check in the waiter's own task (the only place the race outcome is unambiguous), same shape as #73/#74 — plus the part specific to this type: **the consumed signal must be forwarded, not dropped**. `signal()` is a synchronous same-actor call from `wait()`, so the forward (wake next waiter, or restore the count) completes before `wait()` throws. Interleavings (full analysis in the code comment):

- **Cancellation task wins**: continuation throws; re-check never reached; the racing signal restores a resource. ✓
- **`signal()` wins**: waiter resumed `.signaled`; re-check forwards the signal and throws; pending cancellation task no-ops. ✓
- **Cancelled after resume, before re-check**: same as above — forwarded, not double-consumed; the caller sees the throw and does not signal. ✓
- **Self-resume is structurally impossible**: the forwarding waiter was already extracted from the heap, so its own signal can only reach *other* waiters or the counter. ✓

Error type: throws `PipelineError.cancelled`, matching every existing cancellation path in this type. The doc comment claimed `CancellationError` but the implementation has always thrown `PipelineError.cancelled`; the doc now records reality. (Flagging for review: aligning the whole type on `CancellationError` instead would be a behavior change for existing catch sites, so I left it.)

## Regression tests

`AsyncSemaphoreContractTests` — park a waiter deterministically (poll `waiterCount()`), race cancel against signal, 200 iterations each:

- **testCancelledWaiterDoesNotSwallowSignal** — `wait()` must throw; then asserts `availableResourcesCount() == 1`, which is deterministic in *every* interleaving because the forward happens synchronously on the actor before the waiter's caller resumes. Pre-fix: fails at iteration 0 (`wait() returned normally in a cancelled task`).
- **testCancelledTimeoutWaiterDoesNotSwallowSignal** — same through `acquire(timeout:)`; must return false + conservation. Pre-fix: fails at iteration 0.

(The direct `signal()` call beats the freshly-spawned cancellation task essentially always, which is why pre-fix failure is immediate — the *bad* order is the common one here.)

## Verification (clean build)

- Pre-fix: both tests fail loudly at iteration 0.
- Post-fix: **70/70** clean runs of the regression suite.
- Full `PipelineKitResilienceTests`: **126 tests, 0 failures** (4 skipped).
- Full `PipelineKitPoolingTests` (ObjectPool is the main `wait()` consumer): **63 tests, 0 failures**.

Note: expect a trivial CHANGELOG conflict with #74/#75 — all three add entries at the top of `[Unreleased] > Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)