### PR TITLE
test: deflake BackPressureTests.testSemaphoreErrorStrategy

### DIFF
--- a/Tests/PipelineKitResilienceTests/BackPressureTests.swift
+++ b/Tests/PipelineKitResilienceTests/BackPressureTests.swift
@@ -66,9 +66,14 @@ final class BackPressureTests: XCTestCase {
             strategy: .error(timeout: nil)
         )
         
-        // First acquisition should succeed
-        _ = try await semaphore.acquire()
-        
+        // First acquisition should succeed. The token must stay alive for the
+        // whole test: discarding it (`_ =`) deallocates it immediately, and
+        // SemaphoreToken's deinit auto-release spawns an unstructured task
+        // that races the second acquire — if it wins, the permit is restored
+        // and the second acquire succeeds instead of throwing (the flake seen
+        // in CI; deterministic with a sleep inserted between the acquires).
+        let holder = try await semaphore.acquire()
+
         // Second acquisition should fail immediately
         do {
             _ = try await semaphore.acquire()
@@ -81,6 +86,8 @@ final class BackPressureTests: XCTestCase {
                 XCTFail("Expected queueFull error, got \(error)")
             }
         }
+
+        holder.release()
     }
     
     func testSemaphoreTimeoutAcquisition() async throws {


### PR DESCRIPTION
## Summary

Deflakes `testSemaphoreErrorStrategy`, which failed on **docs-only** PR #75's CI run (`Expected PipelineError.backPressure`) — definitionally a main flake.

## Root cause

The test discarded its first token: `_ = try await semaphore.acquire()`. The token deallocates immediately, and `SemaphoreToken.deinit` auto-releases by spawning an unstructured task (`Task { await self?.release() }`) that races the test's second `acquire()` for the actor:

- **Second acquire wins** (common): `activeTokens` is still 1, `totalOutstanding + 1 > maxOutstanding` → `.error(nil)` strategy throws `queueFull` → test passes.
- **Release task wins** (loaded runner): the permit is restored first, the second acquire succeeds on the fast path → `XCTFail`.

**Mechanism confirmed**: inserting a 100ms sleep between the two acquires reproduces the exact CI failure deterministically.

## Fix

Hold the token in a named variable for the duration of the test and release it at the end — no release task exists to race, so the `queueFull` outcome is deterministic. The other `_ =` discard sites in this file don't assert exhaustion immediately after a discard, so they're structurally unaffected.

## Verification

30/30 clean local runs post-fix. Test-only change — self-merge when green per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)