### PR TITLE
feat: ExecutionContext task-local propagation below the handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`ExecutionContext` task-local propagation**: `ExecutionContext.current` gives code
+  below the handler — repositories, loggers, helpers at any depth — implicit access to
+  immutable `TraceMetadata` (commandID/correlationID/userID) and an optional
+  `ProgressReporter` capability, bound by both `StandardPipeline` and `DynamicPipeline`
+  around the middleware chain + handler. Attach a reporter via
+  `ContextKeys.progressReporter` and consume a bounded, lossy
+  `AsyncStream<ProgressUpdate>`; the pipeline terminates it on completion or throw.
+  `ExecutionContext.Snapshot` (Codable) + `withRestored(_:progress:)` define the
+  rebind contract for future deferred execution. Purely additive; `current` is `nil`
+  outside pipeline execution and in detached tasks.
+
 ## [0.5.1] - 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ExecutionContext` task-local propagation**: `ExecutionContext.current` gives code
   below the handler — repositories, loggers, helpers at any depth — implicit access to
   immutable `TraceMetadata` (commandID/correlationID/userID) and an optional
-  `ProgressReporter` capability, bound by both `StandardPipeline` and `DynamicPipeline`
-  around the middleware chain + handler. Attach a reporter via
+  `ProgressReporter` capability, bound by `StandardPipeline` around the middleware
+  chain + handler and by `DynamicPipeline` around its entire retry loop. Attach a
+  reporter via
   `ContextKeys.progressReporter` and consume a bounded, lossy
   `AsyncStream<ProgressUpdate>`; the pipeline terminates it on completion or throw.
   `ExecutionContext.Snapshot` (Codable) + `withRestored(_:progress:)` define the

--- a/Sources/PipelineKit/Pipeline/DynamicPipeline.swift
+++ b/Sources/PipelineKit/Pipeline/DynamicPipeline.swift
@@ -195,8 +195,25 @@ public actor DynamicPipeline {
     ) async throws -> T.Result {
         let commandContext = context ?? CommandContext()
 
-        return try await withRetry(retryPolicy: retryPolicy, command: command) {
-            try await self.executePipeline(command: command, context: commandContext)
+        // Bind the task-local ExecutionContext around the entire retry loop
+        // and middleware chain + handler — ensures progress stream survives
+        // all retry attempts and finishes exactly once after final attempt.
+        let executionContext = ExecutionContext(
+            trace: TraceMetadata(
+                commandID: commandContext[ContextKeys.commandID] ?? UUID(),
+                correlationID: commandContext[ContextKeys.correlationID],
+                userID: commandContext[ContextKeys.userID]
+            ),
+            progress: commandContext[ContextKeys.progressReporter]
+        )
+        // Terminate the caller's progress stream once, after all retry attempts
+        // complete or fail; finish() is idempotent.
+        defer { executionContext.progress?.finish() }
+
+        return try await ExecutionContext.$current.withValue(executionContext) {
+            try await withRetry(retryPolicy: retryPolicy, command: command) {
+                try await self.executePipeline(command: command, context: commandContext)
+            }
         }
     }
 

--- a/Sources/PipelineKit/Pipeline/StandardPipeline.swift
+++ b/Sources/PipelineKit/Pipeline/StandardPipeline.swift
@@ -304,14 +304,31 @@ public actor StandardPipeline<C: Command, H: CommandHandler>: Pipeline where H.C
     private func executeWithContext(_ command: C, context: CommandContext) async throws -> C.Result {
         // Always initialize context first
         await initializeContextIfNeeded(context)
-        
-        // Fast path: No middleware
-        if middlewares.isEmpty {
-            return try await handler.handle(command, context: context)
+
+        // Bind the task-local ExecutionContext around the entire chain +
+        // handler (single binding site; middleware benefits too). Trace values
+        // come from the context the caller already populated via metadata.
+        let executionContext = ExecutionContext(
+            trace: TraceMetadata(
+                commandID: context[ContextKeys.commandID] ?? UUID(),
+                correlationID: context[ContextKeys.correlationID],
+                userID: context[ContextKeys.userID]
+            ),
+            progress: context[ContextKeys.progressReporter]
+        )
+        // Terminate the caller's progress stream on success AND throw;
+        // finish() is idempotent.
+        defer { executionContext.progress?.finish() }
+
+        return try await ExecutionContext.$current.withValue(executionContext) {
+            // Fast path: No middleware
+            if middlewares.isEmpty {
+                return try await handler.handle(command, context: context)
+            }
+
+            // Execute through middleware chain without copying middleware array
+            return try await executeWithMiddleware(command, context: context)
         }
-        
-        // Execute through middleware chain without copying middleware array
-        return try await executeWithMiddleware(command, context: context)
     }
     
     /// Initializes standard context values if not already set.

--- a/Sources/PipelineKitCore/Context/ExecutionContext.swift
+++ b/Sources/PipelineKitCore/Context/ExecutionContext.swift
@@ -30,10 +30,13 @@ public struct TraceMetadata: Sendable, Codable, Equatable {
 /// `nil`.
 public struct ExecutionContext: Sendable {
     public let trace: TraceMetadata
+    /// Present only when the caller attached a reporter for this execution.
+    public let progress: ProgressReporter?
 
     @TaskLocal public static var current: ExecutionContext?
 
-    public init(trace: TraceMetadata) {
+    public init(trace: TraceMetadata, progress: ProgressReporter? = nil) {
         self.trace = trace
+        self.progress = progress
     }
 }

--- a/Sources/PipelineKitCore/Context/ExecutionContext.swift
+++ b/Sources/PipelineKitCore/Context/ExecutionContext.swift
@@ -18,8 +18,10 @@ public struct TraceMetadata: Sendable, Codable, Equatable {
     }
 }
 
-/// Task-local view of the current command execution, bound by the pipelines
-/// around the middleware chain and handler.
+/// Task-local view of the current command execution, bound by
+/// `StandardPipeline` around the middleware chain and handler, and by
+/// `DynamicPipeline` around its entire retry loop (all attempts, including
+/// backoff delays, observe the same context).
 ///
 /// Only immutable values and capability handles may be added as fields —
 /// never mutable shared state (see the design doc for why the whole
@@ -28,6 +30,11 @@ public struct TraceMetadata: Sendable, Codable, Equatable {
 /// `current` is `nil` outside pipeline execution and inside `Task.detached`
 /// (task-locals are not inherited by detached tasks); readers must tolerate
 /// `nil`.
+///
+/// Use a fresh `CommandContext` per pipeline execution: pipelines capture the
+/// context's attached `ProgressReporter` when binding, and the first
+/// (innermost) execution to complete finishes that reporter's stream, so a
+/// shared context silently drops the outer execution's later updates.
 public struct ExecutionContext: Sendable {
     public let trace: TraceMetadata
     /// Present only when the caller attached a reporter for this execution.

--- a/Sources/PipelineKitCore/Context/ExecutionContext.swift
+++ b/Sources/PipelineKitCore/Context/ExecutionContext.swift
@@ -40,3 +40,42 @@ public struct ExecutionContext: Sendable {
         self.progress = progress
     }
 }
+
+// MARK: - Snapshot / rebind (deferred-execution contract)
+
+extension ExecutionContext {
+    /// Codable persistence form of an `ExecutionContext`.
+    ///
+    /// Capability handles (`progress`) are deliberately excluded — they cannot
+    /// be serialized. A deferred executor persists the snapshot at enqueue and
+    /// attaches a fresh reporter at replay via `withRestored(_:progress:)`.
+    @frozen
+    public struct Snapshot: Sendable, Codable, Equatable {
+        public let trace: TraceMetadata
+
+        public init(trace: TraceMetadata) {
+            self.trace = trace
+        }
+    }
+
+    public func snapshot() -> Snapshot {
+        Snapshot(trace: trace)
+    }
+
+    /// Rebinds a restored context around `operation` on the current task.
+    ///
+    /// This is the replay half of the deferred-execution contract: task-locals
+    /// do not survive enqueue → dequeue (the work runs on a different task),
+    /// so the worker re-establishes the context explicitly.
+    public static func withRestored<T: Sendable>(
+        _ snapshot: Snapshot,
+        progress: ProgressReporter? = nil,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await ExecutionContext.$current.withValue(
+            ExecutionContext(trace: snapshot.trace, progress: progress)
+        ) {
+            try await operation()
+        }
+    }
+}

--- a/Sources/PipelineKitCore/Context/ExecutionContext.swift
+++ b/Sources/PipelineKitCore/Context/ExecutionContext.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Immutable trace identifiers for one command execution.
+///
+/// A frozen, `Codable` value snapshot — safe to persist (deferred execution)
+/// and to read from any task. Distinct from `PipelineKitSecurity.TraceContext`,
+/// which serves audit logging.
+@frozen
+public struct TraceMetadata: Sendable, Codable, Equatable {
+    public let commandID: UUID
+    public let correlationID: String?
+    public let userID: String?
+
+    public init(commandID: UUID, correlationID: String? = nil, userID: String? = nil) {
+        self.commandID = commandID
+        self.correlationID = correlationID
+        self.userID = userID
+    }
+}
+
+/// Task-local view of the current command execution, bound by the pipelines
+/// around the middleware chain and handler.
+///
+/// Only immutable values and capability handles may be added as fields —
+/// never mutable shared state (see the design doc for why the whole
+/// `CommandContext` is deliberately NOT exposed this way).
+///
+/// `current` is `nil` outside pipeline execution and inside `Task.detached`
+/// (task-locals are not inherited by detached tasks); readers must tolerate
+/// `nil`.
+public struct ExecutionContext: Sendable {
+    public let trace: TraceMetadata
+
+    @TaskLocal public static var current: ExecutionContext?
+
+    public init(trace: TraceMetadata) {
+        self.trace = trace
+    }
+}

--- a/Sources/PipelineKitCore/Context/ProgressReporter.swift
+++ b/Sources/PipelineKitCore/Context/ProgressReporter.swift
@@ -21,9 +21,13 @@ public struct ProgressUpdate: Sendable, Equatable {
 ///
 /// Create the pair with `makeStream`, attach the reporter to the
 /// `CommandContext` via `ContextKeys.progressReporter`, and consume the
-/// stream from the calling side. The pipeline finishes the stream when
-/// execution completes or throws. Reporting never blocks; `report` after
-/// `finish` is a no-op (`AsyncStream.Continuation` semantics).
+/// stream from the calling side. `StandardPipeline` and `DynamicPipeline`
+/// finish the stream when execution completes or throws (`DynamicPipeline`
+/// after its final retry attempt); other `Pipeline` conformers, such as
+/// `AnyStandardPipeline`, do not bind or finish it. Reporting never blocks;
+/// `report` after `finish` is a no-op (`AsyncStream.Continuation` semantics).
+/// Attach a given reporter to only one pipeline execution: whichever
+/// execution finishes first terminates the stream for all of them.
 public struct ProgressReporter: Sendable {
     private let continuation: AsyncStream<ProgressUpdate>.Continuation
 

--- a/Sources/PipelineKitCore/Context/ProgressReporter.swift
+++ b/Sources/PipelineKitCore/Context/ProgressReporter.swift
@@ -1,0 +1,60 @@
+/// One progress update from an executing command.
+///
+/// Delivery is lossy by design: the backing stream buffer is bounded and
+/// drops the oldest updates under pressure, so treat updates as hints, not a
+/// complete event log.
+@frozen
+public struct ProgressUpdate: Sendable, Equatable {
+    /// Completed fraction in `0.0...1.0` when known; `nil` for indeterminate.
+    public let fraction: Double?
+    public let message: String?
+    public let metadata: [String: String]
+
+    public init(fraction: Double? = nil, message: String? = nil, metadata: [String: String] = [:]) {
+        self.fraction = fraction
+        self.message = message
+        self.metadata = metadata
+    }
+}
+
+/// Capability handle for reporting progress from anywhere below the handler.
+///
+/// Create the pair with `makeStream`, attach the reporter to the
+/// `CommandContext` via `ContextKeys.progressReporter`, and consume the
+/// stream from the calling side. The pipeline finishes the stream when
+/// execution completes or throws. Reporting never blocks; `report` after
+/// `finish` is a no-op (`AsyncStream.Continuation` semantics).
+public struct ProgressReporter: Sendable {
+    private let continuation: AsyncStream<ProgressUpdate>.Continuation
+
+    /// - Parameter bufferSize: Maximum buffered updates when the consumer is
+    ///   slow; the oldest are dropped first (`.bufferingNewest`).
+    public static func makeStream(
+        bufferSize: Int = 16
+    ) -> (stream: AsyncStream<ProgressUpdate>, reporter: ProgressReporter) {
+        var continuation: AsyncStream<ProgressUpdate>.Continuation!
+        let stream = AsyncStream<ProgressUpdate>(bufferingPolicy: .bufferingNewest(bufferSize)) {
+            continuation = $0
+        }
+        return (stream, ProgressReporter(continuation: continuation))
+    }
+
+    public func report(
+        fraction: Double? = nil,
+        message: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        continuation.yield(ProgressUpdate(fraction: fraction, message: message, metadata: metadata))
+    }
+
+    /// Terminates the consumer's stream. Idempotent.
+    public func finish() {
+        continuation.finish()
+    }
+}
+
+public extension ContextKeys {
+    /// Attach point for a `ProgressReporter` so the pipeline can move it into
+    /// the task-local `ExecutionContext` (see `ExecutionContext.progress`).
+    static let progressReporter = ContextKey<ProgressReporter>("progressReporter")
+}

--- a/Tests/PipelineKitCoreTests/ExecutionContextSnapshotTests.swift
+++ b/Tests/PipelineKitCoreTests/ExecutionContextSnapshotTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import PipelineKitCore
+
+final class ExecutionContextSnapshotTests: XCTestCase {
+    private func makeTrace() -> TraceMetadata {
+        TraceMetadata(commandID: UUID(), correlationID: "corr-s", userID: "user-s")
+    }
+
+    func testSnapshotCapturesTraceAndRoundTripsThroughCodable() throws {
+        let trace = makeTrace()
+        let snapshot = ExecutionContext(trace: trace).snapshot()
+        XCTAssertEqual(snapshot.trace, trace)
+
+        let data = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(ExecutionContext.Snapshot.self, from: data)
+        XCTAssertEqual(decoded, snapshot)
+    }
+
+    func testWithRestoredBindsTraceAndFreshReporterThenUnwinds() async throws {
+        let snapshot = ExecutionContext.Snapshot(trace: makeTrace())
+        let (stream, reporter) = ProgressReporter.makeStream()
+
+        let seen = await ExecutionContext.withRestored(snapshot, progress: reporter) {
+            ExecutionContext.current?.progress?.report(message: "from-worker")
+            return ExecutionContext.current?.trace
+        }
+        XCTAssertEqual(seen, snapshot.trace)
+        XCTAssertNil(ExecutionContext.current, "Binding must unwind after withRestored")
+
+        reporter.finish()
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+        XCTAssertEqual(messages, ["from-worker"], "Restored context must carry the fresh reporter")
+    }
+
+    func testNestedWithRestoredShadowsOuterBindingAndUnwinds() async throws {
+        let outer = makeTrace()
+        let inner = makeTrace()
+
+        await ExecutionContext.$current.withValue(ExecutionContext(trace: outer)) {
+            let seenInner = await ExecutionContext.withRestored(.init(trace: inner)) {
+                ExecutionContext.current?.trace
+            }
+            XCTAssertEqual(seenInner, inner, "Inner binding must shadow the outer one")
+            XCTAssertEqual(ExecutionContext.current?.trace, outer, "Outer binding must be restored")
+        }
+    }
+}

--- a/Tests/PipelineKitCoreTests/ExecutionContextTests.swift
+++ b/Tests/PipelineKitCoreTests/ExecutionContextTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import PipelineKitCore
+
+final class ExecutionContextTests: XCTestCase {
+    private func makeTrace() -> TraceMetadata {
+        TraceMetadata(commandID: UUID(), correlationID: "corr-1", userID: "user-1")
+    }
+
+    func testCurrentIsNilOutsideAnyBinding() {
+        XCTAssertNil(ExecutionContext.current)
+    }
+
+    func testBindingIsVisibleAtDepthAndInChildTasks() async throws {
+        let trace = makeTrace()
+
+        // Simulates a repository/helper N frames below the handler.
+        func deepHelper() -> TraceMetadata? {
+            ExecutionContext.current?.trace
+        }
+
+        try await ExecutionContext.$current.withValue(ExecutionContext(trace: trace)) {
+            XCTAssertEqual(deepHelper(), trace)
+
+            // Structured child tasks inherit task-locals.
+            let fromChild = try await withThrowingTaskGroup(of: TraceMetadata?.self) { group -> TraceMetadata? in
+                group.addTask { ExecutionContext.current?.trace }
+                return try await group.next() ?? nil
+            }
+            XCTAssertEqual(fromChild, trace)
+        }
+        XCTAssertNil(ExecutionContext.current, "Binding must unwind after withValue")
+    }
+
+    func testDetachedTaskDoesNotInherit() async {
+        let trace = makeTrace()
+        await ExecutionContext.$current.withValue(ExecutionContext(trace: trace)) {
+            let seenInDetached = await Task.detached { ExecutionContext.current }.value
+            XCTAssertNil(seenInDetached, "Task.detached must not inherit task-locals (documented sharp edge)")
+        }
+    }
+
+    func testTraceMetadataIsCodable() throws {
+        let trace = makeTrace()
+        let data = try JSONEncoder().encode(trace)
+        let decoded = try JSONDecoder().decode(TraceMetadata.self, from: data)
+        XCTAssertEqual(decoded, trace)
+    }
+}

--- a/Tests/PipelineKitCoreTests/ProgressReporterTests.swift
+++ b/Tests/PipelineKitCoreTests/ProgressReporterTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import PipelineKitCore
+
+final class ProgressReporterTests: XCTestCase {
+    func testUpdatesDeliveredInOrder() async {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        reporter.report(fraction: 0.25, message: "a")
+        reporter.report(fraction: 0.5, message: "b")
+        reporter.finish()
+
+        var received: [ProgressUpdate] = []
+        for await update in stream { received.append(update) }
+
+        XCTAssertEqual(received.map(\.message), ["a", "b"])
+        XCTAssertEqual(received.map(\.fraction), [0.25, 0.5])
+    }
+
+    func testReportAfterFinishIsANoOp() async {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        reporter.report(message: "before")
+        reporter.finish()
+        reporter.report(message: "after") // must be dropped silently
+
+        var received: [String?] = []
+        for await update in stream { received.append(update.message) }
+
+        XCTAssertEqual(received, ["before"])
+    }
+
+    func testFinishIsIdempotent() async {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        reporter.finish()
+        reporter.finish() // second finish must not crash or hang
+
+        var count = 0
+        for await _ in stream { count += 1 }
+        XCTAssertEqual(count, 0)
+    }
+
+    func testDropOldestWhenBufferOverflows() async {
+        // No consumer attached while reporting: buffer of 2 must retain only
+        // the NEWEST two updates (bounded, drop-oldest per the spec).
+        let (stream, reporter) = ProgressReporter.makeStream(bufferSize: 2)
+        for i in 0..<5 { reporter.report(message: "u\(i)") }
+        reporter.finish()
+
+        var received: [String?] = []
+        for await update in stream { received.append(update.message) }
+
+        XCTAssertEqual(received, ["u3", "u4"], "Bounded buffer must keep only the newest updates")
+    }
+
+    func testReportingNeverBlocksWithoutConsumer() {
+        let (stream, reporter) = ProgressReporter.makeStream(bufferSize: 1)
+        for i in 0..<1_000 { reporter.report(fraction: Double(i) / 1_000) }
+        // Reaching this line without deadlock IS the assertion.
+        reporter.finish()
+        _ = stream
+    }
+
+    func testProgressReporterContextKeyRoundTrips() {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+        XCTAssertNotNil(context[ContextKeys.progressReporter])
+        reporter.finish()
+        _ = stream
+    }
+}

--- a/Tests/PipelineKitTests/ExecutionContextBindingTests.swift
+++ b/Tests/PipelineKitTests/ExecutionContextBindingTests.swift
@@ -28,6 +28,24 @@ private struct ThrowingHandler: CommandHandler {
     }
 }
 
+// Handler that fails once then succeeds on retry, reporting progress
+private actor AttemptTrackingHandler: CommandHandler {
+    private var attemptCount = 0
+
+    func handle(_ command: ProbeCommand, context: CommandContext) async throws -> TraceMetadata? {
+        attemptCount += 1
+        let count = attemptCount
+
+        if count == 1 {
+            ExecutionContext.current?.progress?.report(message: "attempt-1-failed")
+            throw ProbeError()
+        }
+        ExecutionContext.current?.progress?.report(message: "attempt-2-succeeded")
+        return deepHelperTrace()
+    }
+}
+
+
 // Actor to safely capture trace observed in middleware
 private actor TraceCapture: Sendable {
     private var captured: TraceMetadata? = nil
@@ -127,5 +145,64 @@ final class ExecutionContextBindingTests: XCTestCase {
         XCTAssertEqual(handlerSaw?.commandID, middlewareSaw?.commandID)
         XCTAssertEqual(handlerSaw?.correlationID, middlewareSaw?.correlationID)
         XCTAssertEqual(handlerSaw?.userID, middlewareSaw?.userID)
+    }
+
+    func testDynamicPipelineBindsSameTraceAsStandardPipeline() async throws {
+        let metadata = DefaultCommandMetadata(userID: "user-p", correlationID: "corr-p")
+
+        let standard = StandardPipeline(handler: ProbeHandler())
+        let viaStandard = try await standard.execute(
+            ProbeCommand(), context: CommandContext(metadata: metadata)
+        )
+
+        let dynamic = DynamicPipeline()
+        await dynamic.register(ProbeCommand.self, handler: ProbeHandler())
+        let viaDynamic = try await dynamic.execute(
+            ProbeCommand(), context: CommandContext(metadata: metadata)
+        )
+
+        XCTAssertNotNil(viaStandard)
+        XCTAssertEqual(viaStandard, viaDynamic, "Both pipelines must bind identical trace for the same metadata")
+    }
+
+    func testDynamicPipelineFinishesProgressStream() async throws {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let dynamic = DynamicPipeline()
+        await dynamic.register(ProbeCommand.self, handler: ProbeHandler())
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        _ = try await dynamic.execute(ProbeCommand(), context: context)
+
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+        XCTAssertEqual(messages, ["probing"])
+    }
+
+    func testDynamicPipelineDeliversProgressFromRetryAttempt() async throws {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let dynamic = DynamicPipeline()
+        let handler = AttemptTrackingHandler()
+        await dynamic.register(ProbeCommand.self, handler: handler)
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        // Use retry policy that retries on failure
+        let result = try await dynamic.send(
+            ProbeCommand(),
+            context: context,
+            retryPolicy: RetryPolicy(maxAttempts: 2)
+        )
+
+        // Should have succeeded on attempt 2
+        XCTAssertNotNil(result)
+
+        // Collect all progress messages from the stream
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+
+        // Stream should contain both messages and complete (not drop attempt-2 message)
+        XCTAssertEqual(messages, ["attempt-1-failed", "attempt-2-succeeded"],
+                       "Progress stream must deliver messages from all retry attempts before finishing")
     }
 }

--- a/Tests/PipelineKitTests/ExecutionContextBindingTests.swift
+++ b/Tests/PipelineKitTests/ExecutionContextBindingTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+import PipelineKit
+import PipelineKitCore
+
+// Reads the task-local from a plain function several frames below the
+// handler — the whole point of the feature.
+private func deepHelperTrace() -> TraceMetadata? {
+    ExecutionContext.current?.trace
+}
+
+private struct ProbeCommand: Command {
+    typealias Result = TraceMetadata?
+}
+
+private struct ProbeHandler: CommandHandler {
+    func handle(_ command: ProbeCommand, context: CommandContext) async throws -> TraceMetadata? {
+        ExecutionContext.current?.progress?.report(fraction: 0.5, message: "probing")
+        return deepHelperTrace()
+    }
+}
+
+private struct ProbeError: Error {}
+
+private struct ThrowingHandler: CommandHandler {
+    func handle(_ command: ProbeCommand, context: CommandContext) async throws -> TraceMetadata? {
+        ExecutionContext.current?.progress?.report(message: "before-throw")
+        throw ProbeError()
+    }
+}
+
+// Actor to safely capture trace observed in middleware
+private actor TraceCapture: Sendable {
+    private var captured: TraceMetadata? = nil
+
+    func capture(_ trace: TraceMetadata?) {
+        self.captured = trace
+    }
+
+    func getCaptured() -> TraceMetadata? {
+        self.captured
+    }
+}
+
+// Middleware that captures the current ExecutionContext trace
+private struct TraceCapturingMiddleware: Middleware {
+    let priority = ExecutionPriority.custom
+    let capture: TraceCapture
+
+    func execute<T: Command>(
+        _ command: T,
+        context: CommandContext,
+        next: @escaping MiddlewareNext<T>
+    ) async throws -> T.Result {
+        // Capture the trace inside the middleware to prove binding wraps it
+        await capture.capture(ExecutionContext.current?.trace)
+        return try await next(command, context)
+    }
+}
+
+final class ExecutionContextBindingTests: XCTestCase {
+    func testStandardPipelineBindsTraceFromContextMetadata() async throws {
+        let pipeline = StandardPipeline(handler: ProbeHandler())
+        let metadata = DefaultCommandMetadata(userID: "user-1", correlationID: "corr-1")
+        let context = CommandContext(metadata: metadata)
+
+        let seen = try await pipeline.execute(ProbeCommand(), context: context)
+
+        XCTAssertEqual(seen?.commandID, metadata.id)
+        XCTAssertEqual(seen?.correlationID, "corr-1")
+        XCTAssertEqual(seen?.userID, "user-1")
+        XCTAssertNil(ExecutionContext.current, "Binding must not leak past execute")
+    }
+
+    func testStandardPipelineDeliversProgressAndFinishesStreamOnSuccess() async throws {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let pipeline = StandardPipeline(handler: ProbeHandler())
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        _ = try await pipeline.execute(ProbeCommand(), context: context)
+
+        // The for-await loop completing proves the pipeline finished the stream.
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+        XCTAssertEqual(messages, ["probing"])
+    }
+
+    func testStandardPipelineFinishesStreamWhenHandlerThrows() async {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let pipeline = StandardPipeline(handler: ThrowingHandler())
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        do {
+            _ = try await pipeline.execute(ProbeCommand(), context: context)
+            XCTFail("ThrowingHandler must throw")
+        } catch is ProbeError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+        XCTAssertEqual(messages, ["before-throw"], "Stream must terminate even on a throwing handler")
+    }
+
+    func testStandardPipelineBindsTraceAroundMiddlewareChain() async throws {
+        let capture = TraceCapture()
+        let pipeline = StandardPipeline(handler: ProbeHandler())
+        try await pipeline.addMiddleware(TraceCapturingMiddleware(capture: capture))
+
+        let metadata = DefaultCommandMetadata(userID: "middleware-user", correlationID: "middleware-corr")
+        let context = CommandContext(metadata: metadata)
+
+        let handlerSaw = try await pipeline.execute(ProbeCommand(), context: context)
+        let middlewareSaw = await capture.getCaptured()
+
+        // Both middleware and handler should see the same trace
+        XCTAssertNotNil(middlewareSaw, "Middleware must see ExecutionContext.current")
+        XCTAssertEqual(middlewareSaw?.commandID, metadata.id)
+        XCTAssertEqual(middlewareSaw?.correlationID, "middleware-corr")
+        XCTAssertEqual(middlewareSaw?.userID, "middleware-user")
+
+        // Handler should see the same trace (proving binding wraps the whole chain)
+        XCTAssertNotNil(handlerSaw)
+        XCTAssertEqual(handlerSaw?.commandID, middlewareSaw?.commandID)
+        XCTAssertEqual(handlerSaw?.correlationID, middlewareSaw?.correlationID)
+        XCTAssertEqual(handlerSaw?.userID, middlewareSaw?.userID)
+    }
+}


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-07-25-execution-context-design.md — see spec for design rationale and rejected alternatives. Purely additive API; existing suites unchanged. Production change: left open for review per repo policy.

## Review notes

**Approved deviation from the plan (Task 5):** the plan placed DynamicPipeline's ExecutionContext binding inside `executePipeline`. Task review found that placement finishes the caller's progress stream after a failed first retry attempt (`send()`'s `withRetry` wraps `executePipeline`, default policy retries any error), silently dropping progress from later attempts. With approval, the binding moved up into `send()` around the whole retry loop; `testDynamicPipelineDeliversProgressFromRetryAttempt` is the regression test (verified failing before the fix). StandardPipeline has no retry wrapper, so its binding is per the plan.

**Final whole-branch review outcome:** no Critical findings. One Important finding — nested pipeline executions sharing a single `CommandContext` let the innermost completion finish the outer caller's progress stream — resolved by documenting the sharp edge (use a fresh `CommandContext` per execution) in the API docs, per the reviewer's minimum bar.

**Deferred follow-ups (non-blocking):**
- Progress inheritance for nested executions (bind inherits enclosing `ExecutionContext.current?.progress` when the context carries no reporter) as the full fix for the sharp edge above.
- `withRestored`: add an `isolation:` passthrough parameter and relax the `T: Sendable` constraint before the deferred executor consumes it (source-compatible either way).
- `precondition(bufferSize > 0)` in `ProgressReporter.makeStream` (`bufferingNewest(0)` silently drops everything).
- A DynamicPipeline all-attempts-exhausted stream-termination test (currently guaranteed structurally by `defer`, covered only on the fail-then-succeed path).

**Verification:** filtered targets 265+155+128 tests, 0 failures; `swift test --parallel --skip PipelineKitPerformanceTests` exit 0 (938 XCTest + 20 Swift Testing cases); ExecutionContextBindingTests 7/7. Full unfiltered suite to be run in Xcode as the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
