### PR TITLE
ExecutionContext follow-ups: progress inheritance, withRestored isolation, makeStream precondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TaskLocal.withValue`) and the result's `T: Sendable` bound is removed, so
   actor-isolated callers can mutate their own state inside `operation`.
   Source-compatible.
+- **`ProgressReporter.makeStream` now requires `bufferSize > 0`** (precondition):
+  `.bufferingNewest(0)` silently dropped every update, a footgun with no valid use.
 
 ## [0.5.1] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rebind contract for future deferred execution. Purely additive; `current` is `nil`
   outside pipeline execution and in detached tasks.
 
+### Changed
+- **Nested pipeline executions inherit the enclosing execution's progress reporter**:
+  when `StandardPipeline` or `DynamicPipeline` binds a `CommandContext` that attaches
+  no `ProgressReporter`, `ExecutionContext.current?.progress` now resolves to the
+  enclosing execution's reporter at any nesting depth, so inner executions report into
+  the outer stream with no caller wiring. Ownership is unchanged: only the execution
+  whose context attached the reporter finishes the stream.
+
 ## [0.5.1] - 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enclosing execution's reporter at any nesting depth, so inner executions report into
   the outer stream with no caller wiring. Ownership is unchanged: only the execution
   whose context attached the reporter finishes the stream.
+- **`ExecutionContext.withRestored` forwards caller isolation**: new
+  `isolation: isolated (any Actor)? = #isolation` parameter (mirroring
+  `TaskLocal.withValue`) and the result's `T: Sendable` bound is removed, so
+  actor-isolated callers can mutate their own state inside `operation`.
+  Source-compatible.
 
 ## [0.5.1] - 2026-07-25
 

--- a/Sources/PipelineKit/Pipeline/DynamicPipeline.swift
+++ b/Sources/PipelineKit/Pipeline/DynamicPipeline.swift
@@ -197,18 +197,23 @@ public actor DynamicPipeline {
 
         // Bind the task-local ExecutionContext around the entire retry loop
         // and middleware chain + handler — ensures progress stream survives
-        // all retry attempts and finishes exactly once after final attempt.
+        // all retry attempts. Trace is never inherited from an enclosing
+        // execution.
+        let attached = commandContext[ContextKeys.progressReporter]
         let executionContext = ExecutionContext(
             trace: TraceMetadata(
                 commandID: commandContext[ContextKeys.commandID] ?? UUID(),
                 correlationID: commandContext[ContextKeys.correlationID],
                 userID: commandContext[ContextKeys.userID]
             ),
-            progress: commandContext[ContextKeys.progressReporter]
+            // Visibility: a nested execution whose context attaches no
+            // reporter inherits the enclosing execution's reporter.
+            progress: attached ?? ExecutionContext.current?.progress
         )
-        // Terminate the caller's progress stream once, after all retry attempts
-        // complete or fail; finish() is idempotent.
-        defer { executionContext.progress?.finish() }
+        // Ownership: finish only what THIS context attached, once, after all
+        // retry attempts complete or fail; finish() is idempotent. An
+        // inherited reporter belongs to the execution that attached it.
+        defer { attached?.finish() }
 
         return try await ExecutionContext.$current.withValue(executionContext) {
             try await withRetry(retryPolicy: retryPolicy, command: command) {

--- a/Sources/PipelineKit/Pipeline/StandardPipeline.swift
+++ b/Sources/PipelineKit/Pipeline/StandardPipeline.swift
@@ -307,18 +307,23 @@ public actor StandardPipeline<C: Command, H: CommandHandler>: Pipeline where H.C
 
         // Bind the task-local ExecutionContext around the entire chain +
         // handler (single binding site; middleware benefits too). Trace values
-        // come from the context the caller already populated via metadata.
+        // come from the context the caller already populated via metadata;
+        // trace is never inherited from an enclosing execution.
+        let attached = context[ContextKeys.progressReporter]
         let executionContext = ExecutionContext(
             trace: TraceMetadata(
                 commandID: context[ContextKeys.commandID] ?? UUID(),
                 correlationID: context[ContextKeys.correlationID],
                 userID: context[ContextKeys.userID]
             ),
-            progress: context[ContextKeys.progressReporter]
+            // Visibility: a nested execution whose context attaches no
+            // reporter inherits the enclosing execution's reporter.
+            progress: attached ?? ExecutionContext.current?.progress
         )
-        // Terminate the caller's progress stream on success AND throw;
-        // finish() is idempotent.
-        defer { executionContext.progress?.finish() }
+        // Ownership: finish only what THIS context attached — an inherited
+        // reporter belongs to the execution that attached it. Runs on
+        // success AND throw; finish() is idempotent.
+        defer { attached?.finish() }
 
         return try await ExecutionContext.$current.withValue(executionContext) {
             // Fast path: No middleware

--- a/Sources/PipelineKitCore/Context/ExecutionContext.swift
+++ b/Sources/PipelineKitCore/Context/ExecutionContext.swift
@@ -31,13 +31,19 @@ public struct TraceMetadata: Sendable, Codable, Equatable {
 /// (task-locals are not inherited by detached tasks); readers must tolerate
 /// `nil`.
 ///
-/// Use a fresh `CommandContext` per pipeline execution: pipelines capture the
-/// context's attached `ProgressReporter` when binding, and the first
-/// (innermost) execution to complete finishes that reporter's stream, so a
-/// shared context silently drops the outer execution's later updates.
+/// Nested executions inherit progress visibility: when a pipeline binds a
+/// `CommandContext` that attaches no reporter, `progress` resolves to the
+/// enclosing execution's reporter, at any nesting depth. Ownership does not
+/// flow with it — only the execution whose context attached the reporter
+/// finishes the stream. Trace is never inherited; each execution's
+/// `TraceMetadata` comes from its own context. Prefer a fresh
+/// `CommandContext` per execution: sharing one context makes the inner
+/// execution the attacher, so it finishes the stream early.
 public struct ExecutionContext: Sendable {
     public let trace: TraceMetadata
-    /// Present only when the caller attached a reporter for this execution.
+    /// The reporter attached by this execution's context, or inherited from
+    /// the enclosing execution when none was attached; `nil` when neither
+    /// exists. Only the attaching execution finishes the stream.
     public let progress: ProgressReporter?
 
     @TaskLocal public static var current: ExecutionContext?

--- a/Sources/PipelineKitCore/Context/ExecutionContext.swift
+++ b/Sources/PipelineKitCore/Context/ExecutionContext.swift
@@ -80,15 +80,21 @@ extension ExecutionContext {
     /// This is the replay half of the deferred-execution contract: task-locals
     /// do not survive enqueue → dequeue (the work runs on a different task),
     /// so the worker re-establishes the context explicitly.
-    public static func withRestored<T: Sendable>(
+    ///
+    /// `operation` runs in the caller's isolation (`#isolation` by default,
+    /// mirroring `TaskLocal.withValue`), so actor-isolated callers may touch
+    /// their own state inside it. The restored context never inherits an
+    /// enclosing execution's reporter — `progress` is the only source.
+    public static func withRestored<T>(
         _ snapshot: Snapshot,
         progress: ProgressReporter? = nil,
+        isolation: isolated (any Actor)? = #isolation,
         operation: () async throws -> T
     ) async rethrows -> T {
         try await ExecutionContext.$current.withValue(
-            ExecutionContext(trace: snapshot.trace, progress: progress)
-        ) {
-            try await operation()
-        }
+            ExecutionContext(trace: snapshot.trace, progress: progress),
+            operation: operation,
+            isolation: isolation
+        )
     }
 }

--- a/Sources/PipelineKitCore/Context/ProgressReporter.swift
+++ b/Sources/PipelineKitCore/Context/ProgressReporter.swift
@@ -26,8 +26,9 @@ public struct ProgressUpdate: Sendable, Equatable {
 /// after its final retry attempt); other `Pipeline` conformers, such as
 /// `AnyStandardPipeline`, do not bind or finish it. Reporting never blocks;
 /// `report` after `finish` is a no-op (`AsyncStream.Continuation` semantics).
-/// Attach a given reporter to only one pipeline execution: whichever
-/// execution finishes first terminates the stream for all of them.
+/// Only the execution whose `CommandContext` attached the reporter finishes
+/// the stream; nested executions that attach no reporter of their own
+/// inherit it for reporting but never finish it.
 public struct ProgressReporter: Sendable {
     private let continuation: AsyncStream<ProgressUpdate>.Continuation
 

--- a/Sources/PipelineKitCore/Context/ProgressReporter.swift
+++ b/Sources/PipelineKitCore/Context/ProgressReporter.swift
@@ -33,10 +33,12 @@ public struct ProgressReporter: Sendable {
     private let continuation: AsyncStream<ProgressUpdate>.Continuation
 
     /// - Parameter bufferSize: Maximum buffered updates when the consumer is
-    ///   slow; the oldest are dropped first (`.bufferingNewest`).
+    ///   slow; the oldest are dropped first (`.bufferingNewest`). Must be > 0
+    ///   — `.bufferingNewest(0)` would silently drop every update.
     public static func makeStream(
         bufferSize: Int = 16
     ) -> (stream: AsyncStream<ProgressUpdate>, reporter: ProgressReporter) {
+        precondition(bufferSize > 0, "ProgressReporter.makeStream bufferSize must be > 0")
         var continuation: AsyncStream<ProgressUpdate>.Continuation!
         let stream = AsyncStream<ProgressUpdate>(bufferingPolicy: .bufferingNewest(bufferSize)) {
             continuation = $0

--- a/Tests/PipelineKitCoreTests/ExecutionContextSnapshotTests.swift
+++ b/Tests/PipelineKitCoreTests/ExecutionContextSnapshotTests.swift
@@ -1,6 +1,23 @@
 import XCTest
 @testable import PipelineKitCore
 
+// Compiles only if withRestored forwards the caller's isolation: the
+// operation mutates actor state synchronously, which a nonisolated
+// closure could not do under Swift 6 strict concurrency.
+private actor RestoreCounter {
+    private(set) var count = 0
+
+    func restoreAndIncrement(
+        _ snapshot: ExecutionContext.Snapshot
+    ) async -> (inside: TraceMetadata?, after: TraceMetadata?) {
+        let inside = await ExecutionContext.withRestored(snapshot) {
+            count += 1  // actor-isolated mutation inside `operation`
+            return ExecutionContext.current?.trace
+        }
+        return (inside, ExecutionContext.current?.trace)
+    }
+}
+
 final class ExecutionContextSnapshotTests: XCTestCase {
     private func makeTrace() -> TraceMetadata {
         TraceMetadata(commandID: UUID(), correlationID: "corr-s", userID: "user-s")
@@ -44,5 +61,17 @@ final class ExecutionContextSnapshotTests: XCTestCase {
             XCTAssertEqual(seenInner, inner, "Inner binding must shadow the outer one")
             XCTAssertEqual(ExecutionContext.current?.trace, outer, "Outer binding must be restored")
         }
+    }
+
+    func testWithRestoredRunsOperationInCallerIsolation() async throws {
+        let snapshot = ExecutionContext.Snapshot(trace: makeTrace())
+        let counter = RestoreCounter()
+
+        let (inside, after) = await counter.restoreAndIncrement(snapshot)
+
+        XCTAssertEqual(inside, snapshot.trace, "Binding must be visible inside operation")
+        XCTAssertNil(after, "Binding must unwind after withRestored returns")
+        let count = await counter.count
+        XCTAssertEqual(count, 1, "Operation must have run isolated to the actor")
     }
 }

--- a/Tests/PipelineKitTests/ExecutionContextBindingTests.swift
+++ b/Tests/PipelineKitTests/ExecutionContextBindingTests.swift
@@ -57,6 +57,42 @@ private actor AlwaysFailingHandler: CommandHandler {
     }
 }
 
+// Inner handler for nesting tests: reports into whatever reporter the
+// execution context resolves — inherited, if inheritance works.
+private struct InnerReportingHandler: CommandHandler {
+    func handle(_ command: ProbeCommand, context: CommandContext) async throws -> TraceMetadata? {
+        ExecutionContext.current?.progress?.report(message: "inner")
+        return deepHelperTrace()
+    }
+}
+
+// Outer handler that delegates to an inner StandardPipeline with a fresh
+// CommandContext (no reporter attached), then reports after the inner
+// execution returns.
+private struct StandardNestingHandler: CommandHandler {
+    let inner: StandardPipeline<ProbeCommand, InnerReportingHandler>
+
+    func handle(_ command: ProbeCommand, context: CommandContext) async throws -> TraceMetadata? {
+        _ = try await inner.execute(ProbeCommand(), context: CommandContext(metadata: DefaultCommandMetadata()))
+        // Reported AFTER the inner execution returned: only deliverable if
+        // the inner completion did not finish the inherited stream.
+        ExecutionContext.current?.progress?.report(message: "outer-after-inner")
+        return deepHelperTrace()
+    }
+}
+
+// Same shape with an inner DynamicPipeline — covers the send() binding
+// site's non-finish of inherited reporters, including its retry defer.
+private struct DynamicNestingHandler: CommandHandler {
+    let inner: DynamicPipeline
+
+    func handle(_ command: ProbeCommand, context: CommandContext) async throws -> TraceMetadata? {
+        _ = try await inner.send(ProbeCommand(), context: CommandContext(metadata: DefaultCommandMetadata()))
+        ExecutionContext.current?.progress?.report(message: "outer-after-inner")
+        return deepHelperTrace()
+    }
+}
+
 // Actor to safely capture trace observed in middleware
 private actor TraceCapture: Sendable {
     private var captured: TraceMetadata? = nil
@@ -243,5 +279,39 @@ final class ExecutionContextBindingTests: XCTestCase {
         for await update in stream { messages.append(update.message) }
         XCTAssertEqual(messages, ["attempt-1", "attempt-2"],
                        "Stream must deliver every attempt's report, then finish, when retries are exhausted")
+    }
+
+    func testNestedStandardPipelineInheritsReporterAndOuterOwnsStream() async throws {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let inner = StandardPipeline(handler: InnerReportingHandler())
+        let outer = StandardPipeline(handler: StandardNestingHandler(inner: inner))
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        _ = try await outer.execute(ProbeCommand(), context: context)
+
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+        // "inner" proves visibility inheritance; "outer-after-inner" proves
+        // the inner completion did not finish the stream; the loop
+        // terminating proves the outer execution did.
+        XCTAssertEqual(messages, ["inner", "outer-after-inner"],
+                       "Inner execution must report into the inherited stream without finishing it")
+    }
+
+    func testNestedDynamicPipelineInheritsReporterAndOuterOwnsStream() async throws {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let inner = DynamicPipeline()
+        await inner.register(ProbeCommand.self, handler: InnerReportingHandler())
+        let outer = StandardPipeline(handler: DynamicNestingHandler(inner: inner))
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        _ = try await outer.execute(ProbeCommand(), context: context)
+
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+        XCTAssertEqual(messages, ["inner", "outer-after-inner"],
+                       "DynamicPipeline.send must inherit the reporter without finishing it")
     }
 }

--- a/Tests/PipelineKitTests/ExecutionContextBindingTests.swift
+++ b/Tests/PipelineKitTests/ExecutionContextBindingTests.swift
@@ -45,6 +45,17 @@ private actor AttemptTrackingHandler: CommandHandler {
     }
 }
 
+// Handler that reports then throws on every attempt — pins stream
+// termination when all retry attempts are exhausted.
+private actor AlwaysFailingHandler: CommandHandler {
+    private var attemptCount = 0
+
+    func handle(_ command: ProbeCommand, context: CommandContext) async throws -> TraceMetadata? {
+        attemptCount += 1
+        ExecutionContext.current?.progress?.report(message: "attempt-\(attemptCount)")
+        throw ProbeError()
+    }
+}
 
 // Actor to safely capture trace observed in middleware
 private actor TraceCapture: Sendable {
@@ -204,5 +215,33 @@ final class ExecutionContextBindingTests: XCTestCase {
         // Stream should contain both messages and complete (not drop attempt-2 message)
         XCTAssertEqual(messages, ["attempt-1-failed", "attempt-2-succeeded"],
                        "Progress stream must deliver messages from all retry attempts before finishing")
+    }
+
+    func testDynamicPipelineFinishesStreamWhenAllRetriesExhausted() async throws {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let dynamic = DynamicPipeline()
+        await dynamic.register(ProbeCommand.self, handler: AlwaysFailingHandler())
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        do {
+            _ = try await dynamic.send(
+                ProbeCommand(),
+                context: context,
+                retryPolicy: RetryPolicy(maxAttempts: 2)
+            )
+            XCTFail("AlwaysFailingHandler must exhaust retries and throw")
+        } catch is ProbeError {
+            // Expected: the final attempt's error propagates unwrapped.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        // The for-await loop terminating proves send() finished the stream
+        // after the final failed attempt.
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+        XCTAssertEqual(messages, ["attempt-1", "attempt-2"],
+                       "Stream must deliver every attempt's report, then finish, when retries are exhausted")
     }
 }


### PR DESCRIPTION
Implements the four follow-ups deferred in PR #79 (spec: `docs/superpowers/specs/2026-07-26-context-followups-design.md`, plan: `docs/superpowers/plans/2026-07-26-context-followups.md`).

## Changes

1. **Exhausted-retries pin test** (`75fe56a`, test-only): `testDynamicPipelineFinishesStreamWhenAllRetriesExhausted` converts the `defer`-based structural guarantee into pinned behavior — after the final failed attempt, the handler's error propagates unwrapped and the attached stream finishes.
2. **Progress inheritance — inherit visibility, owner finishes** (`d8bdd17`): at both binding sites (`StandardPipeline.executeWithContext`, `DynamicPipeline.send`), reporter handling splits into visibility (`attached ?? ExecutionContext.current?.progress` — a nested execution whose context attaches no reporter inherits the enclosing execution's) and ownership (`defer { attached?.finish() }` — only the attaching execution finishes the stream). Trace is never inherited; shared-context behavior is unchanged. Two nesting tests (Standard→Standard, Standard→Dynamic) written RED-first; doc comments recast the fresh-context pattern from warning to recommendation.
3. **`withRestored` isolation passthrough** (`73c911f`): adds `isolation: isolated (any Actor)? = #isolation` forwarded to `TaskLocal.withValue` (SE-0420 shape) and drops the `T: Sendable` bound, so actor-isolated callers can mutate their own state inside `operation`. Source-compatible — the three pre-existing snapshot tests pass unchanged; new actor-mutation test is the compile-time proof.
4. **`makeStream` precondition** (`47beda6`): `precondition(bufferSize > 0)` — `.bufferingNewest(0)` silently dropped every update. No death test (XCTest can't trap preconditions); all existing call sites verified positive.

## Review notes

- Executed via subagent-driven development: per-task spec+quality reviews (all four approved, zero Critical/Important findings) plus a final whole-branch review — verdict **Ready to merge: Yes**, all deferred minors triaged LEAVE.
- Process incident, contained: the Task 4 implementer committed to local `main` in the wrong checkout; the commit was cherry-picked onto this branch (content byte-identical, CHANGELOG bullet placed third in the existing `### Changed` section) and local `main` was reset to `d16ce9b` (= origin/main). Nothing was pushed from the wrong branch.

## Deferred follow-ups (from the final review; none block merge)

- Test-only fast-follow (~40 lines): depth-3+ nesting test, inner-execution-throws-with-inherited-reporter test, trace-distinct assertion in the nesting tests, `withRestored` progress-nil-inside-bound-execution assertion; trim `DynamicNestingHandler`'s over-broad "retry defer" comment.
- **Pre-existing hazard (outside this branch's range)**: `StandardPipeline` can throw *before* reaching the binding site (command-type guard, pre-start cancellation check, back-pressure `semaphore.acquire()`), leaving an attached reporter's stream unfinished so a consumer's `for await` hangs — contradicting the `ProgressReporter` doc's completes-or-throws claim. `DynamicPipeline` is immune. Worth its own issue: hoist the finish obligation or soften the doc claim.

## Verification

- `swift test --filter "PipelineKitCoreTests\."` — 266/266
- `swift test --filter "PipelineKitTests\."` — 158 + 17, 0 failures
- `swift test --filter "PipelineKitResilienceTests\."` — 128 (4 skipped), 0 failures
- `swift test --parallel --skip PipelineKitPerformanceTests` — exit 0
- TDD evidence per behavioral task (Task 2: RED `["outer-after-inner"]` → GREEN; Task 3: RED = actor-isolation compile failure → GREEN)
- Full unfiltered suite: to be run by @gifton in Xcode before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
