### PR TITLE
Finish attached progress streams on every ConcurrentPipeline exit path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cancellation, or back-pressure rejection — skipped `finish()`, hanging any consumer
   iterating the stream. The finish obligation now lives at the `execute(_:context:)`
   entry point and covers every exit path. `DynamicPipeline` was never affected.
+- **`ConcurrentPipeline` could leave an attached progress stream unfinished**: its
+  handler-not-found, semaphore-acquire, and timeout throws all preceded delegation to
+  the wrapped pipeline, so a reporter attached to the context was never finished. Both
+  `execute` entry points now register the finish obligation first, covering every exit
+  path; when the delegated pipeline finishes the stream first, the repeat `finish()`
+  is a no-op.
 
 ## [0.5.1] - 2026-07-25
 

--- a/Sources/PipelineKitCore/Context/ProgressReporter.swift
+++ b/Sources/PipelineKitCore/Context/ProgressReporter.swift
@@ -25,8 +25,11 @@ public struct ProgressUpdate: Sendable, Equatable {
 /// finish the stream when execution completes or throws — including failures
 /// before the middleware chain starts (type mismatch, pre-start cancellation,
 /// back-pressure rejection), and for `DynamicPipeline` only after its final
-/// retry attempt; other `Pipeline` conformers, such as
-/// `AnyStandardPipeline`, do not bind or finish it. Reporting never blocks;
+/// retry attempt. `ConcurrentPipeline` never binds an execution context, but
+/// it does finish an attached reporter when its execution exits (a delegated
+/// binder pipeline finishes first; the repeat is a no-op). Other `Pipeline`
+/// conformers, such as `AnyStandardPipeline`, do not bind or finish it.
+/// Reporting never blocks;
 /// `report` after `finish` is a no-op (`AsyncStream.Continuation` semantics).
 /// Only the execution whose `CommandContext` attached the reporter finishes
 /// the stream; nested executions that attach no reporter of their own

--- a/Sources/PipelineKitResilienceCore/ConcurrentPipeline.swift
+++ b/Sources/PipelineKitResilienceCore/ConcurrentPipeline.swift
@@ -96,14 +96,22 @@ public actor ConcurrentPipeline: Pipeline {
         _ command: T,
         context: CommandContext
     ) async throws -> T.Result {
+        // Finish what this context attached, on every exit path — including
+        // the handler-not-found and semaphore throws below, which precede
+        // delegation. ConcurrentPipeline never binds an ExecutionContext; a
+        // delegated binder pipeline finishes the stream first and this
+        // repeat finish() is an idempotent no-op.
+        let attached = context[ContextKeys.progressReporter]
+        defer { attached?.finish() }
+
         let key = ObjectIdentifier(T.self)
         guard let pipeline = pipelines[key] else {
             throw PipelineError.handlerNotFound(commandType: String(describing: T.self))
         }
-        
+
         let token = try await semaphore.acquire()
         defer { _ = token } // Keep token alive until end of scope
-        
+
         return try await pipeline.execute(command, context: context)
     }
     
@@ -132,19 +140,25 @@ public actor ConcurrentPipeline: Pipeline {
         context: CommandContext? = nil,
         timeout: TimeInterval
     ) async throws -> T.Result {
+        let commandContext = context ?? CommandContext()
+        // Finish what this context attached, on every exit path — including
+        // the handler-not-found and timeout throws below (see
+        // execute(_:context:) for the ownership rationale).
+        let attached = commandContext[ContextKeys.progressReporter]
+        defer { attached?.finish() }
+
         let key = ObjectIdentifier(T.self)
         guard let pipeline = pipelines[key] else {
             throw PipelineError.handlerNotFound(commandType: String(describing: T.self))
         }
-        
+
         guard let token = try await semaphore.acquire(timeout: timeout) else {
             throw PipelineError.timeout(duration: timeout, command: command)
         }
-        
+
         defer { _ = token } // Keep token alive until end of scope
-        
-        let executionContext = context ?? CommandContext()
-        return try await pipeline.execute(command, context: executionContext)
+
+        return try await pipeline.execute(command, context: commandContext)
     }
     
     /// Executes multiple commands concurrently with individual error handling.

--- a/Tests/PipelineKitResilienceTests/ConcurrentPipelineProgressTests.swift
+++ b/Tests/PipelineKitResilienceTests/ConcurrentPipelineProgressTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+import PipelineKit
+import PipelineKitCore
+import PipelineKitResilience
+
+private struct ProbeCommand: Command {
+    typealias Result = String
+}
+
+private struct ProbeHandler: CommandHandler {
+    func handle(_ command: ProbeCommand, context: CommandContext) async throws -> String {
+        ExecutionContext.current?.progress?.report(message: "handled")
+        return "ok"
+    }
+}
+
+// Races draining `stream` against a timeout; returns true iff the stream
+// terminated (was finished) within `seconds`. Mirrors the helper in
+// PipelineKitTests/ExecutionContextBindingTests.swift — test targets cannot
+// share private helpers, so the duplication is deliberate.
+private func streamTerminates(
+    _ stream: AsyncStream<ProgressUpdate>,
+    within seconds: UInt64 = 2
+) async -> Bool {
+    await withTaskGroup(of: Bool.self) { group in
+        group.addTask {
+            for await _ in stream { }
+            return true
+        }
+        group.addTask {
+            try? await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+            return false
+        }
+        let first = await group.next() ?? false
+        group.cancelAll()
+        return first
+    }
+}
+
+final class ConcurrentPipelineProgressTests: XCTestCase {
+    func testHandlerNotFoundFinishesAttachedStream() async {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let pipeline = ConcurrentPipeline()
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        do {
+            _ = try await pipeline.execute(ProbeCommand(), context: context)
+            XCTFail("Unregistered command type must throw")
+        } catch is PipelineError {
+            // Expected: handlerNotFound.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let terminated = await streamTerminates(stream)
+        XCTAssertTrue(terminated, "Stream must finish when no pipeline is registered")
+    }
+
+    func testHandlerNotFoundFinishesAttachedStreamOnTimeoutVariant() async {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let pipeline = ConcurrentPipeline()
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        do {
+            _ = try await pipeline.execute(ProbeCommand(), context: context, timeout: 1.0)
+            XCTFail("Unregistered command type must throw")
+        } catch is PipelineError {
+            // Expected: handlerNotFound.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let terminated = await streamTerminates(stream)
+        XCTAssertTrue(terminated, "Timeout variant must finish the stream when no pipeline is registered")
+    }
+
+    func testDelegatedExecutionDeliversAndFinishesStream() async throws {
+        let (stream, reporter) = ProgressReporter.makeStream()
+        let concurrent = ConcurrentPipeline()
+        await concurrent.register(ProbeCommand.self, pipeline: StandardPipeline(handler: ProbeHandler()))
+        let context = CommandContext(metadata: DefaultCommandMetadata())
+        context[ContextKeys.progressReporter] = reporter
+
+        let result = try await concurrent.execute(ProbeCommand(), context: context)
+        XCTAssertEqual(result, "ok")
+
+        // The delegated StandardPipeline finishes the stream at its exit;
+        // ConcurrentPipeline's later finish() is an idempotent no-op. The
+        // for-await terminating pins that interaction.
+        var messages: [String?] = []
+        for await update in stream { messages.append(update.message) }
+        XCTAssertEqual(messages, ["handled"],
+                       "Delegated execution must deliver reports and the stream must finish")
+    }
+}


### PR DESCRIPTION
Fixes the last known issue before the v0.5.2 release — PR #81's final review found `ConcurrentPipeline` reproduces the throw-before-finish hang one wrapper out (spec: `docs/superpowers/specs/2026-07-26-concurrent-pipeline-stream-fix-design.md`, plan: `docs/superpowers/plans/2026-07-26-concurrent-pipeline-stream-fix.md`).

## Changes (single commit `868ca23`)

- **Fix**: both `ConcurrentPipeline.execute` variants now register `defer { attached?.finish() }` as their first statement — before the handler-not-found, semaphore-acquire (`BackPressureSemaphore`, so genuine rejection throws, not just cancellation), and timeout throws that previously preceded delegation and left an attached reporter's stream hanging its consumer. The timeout variant normalizes its optional context at the top. The convenience `execute(_:)` and `executeConcurrently` funnel through the fixed entry. **No `ExecutionContext` binding added** — `ConcurrentPipeline` stays a non-binder, now documented with a carve-out in the `ProgressReporter` doc.
- **Tests**: new `ConcurrentPipelineProgressTests` — two RED-first handler-not-found termination tests (race-drain, clean ~2s failure mode) and a delegation pin proving the wrapped-`StandardPipeline` double-finish stays a benign no-op.
- **CHANGELOG**: `### Fixed` bullet appended.

## Review notes

- Subagent-driven development: task review and final whole-branch review both approved with zero Critical/Important findings; final verdict **Ready to merge: Yes**. The reviewer independently verified the funneling claim, the absence of hidden throwing entry points, the non-binder rule, and — since this is the last PR before the tag — that **every `[Unreleased]` CHANGELOG claim is backed by shipped code**.
- `executeConcurrently` with a caller-shared context: first per-command exit finishing the shared stream predates this branch (documented shared-context semantics); this branch only adds error exits to the finishing set, which is the fix's purpose.

## Deferred (non-blocking, for future housekeeping)

- Pre-existing stale `ConcurrentPipeline` doc comments (predate this arc): `- Throws:` names `executionFailed` where the code throws `handlerNotFound`; parameter docs say `metadata` for a `context` parameter; `executeConcurrently` is `async throws` while its doc says it doesn't throw.
- Tests catch `is PipelineError` rather than pattern-matching `.handlerNotFound`.

## Verification

- `swift test --filter "PipelineKitCoreTests\."` — 267/267
- `swift test --filter "PipelineKitTests\."` — 162, 0 failures
- `swift test --filter "PipelineKitResilienceTests\."` — 131 (4 skipped), 0 failures
- `swift test --parallel --skip PipelineKitPerformanceTests` — exit 0
- TDD: both fix tests RED before the change (pin passing), 3/3 GREEN after
- Full unfiltered suite: to be run by @gifton in Xcode before merge

After merge: tag `v0.5.2` + GitHub release with notes from the `[Unreleased]` CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
