### PR TITLE
fix(resilience): circuit breaker probe lifecycle — abandoned probes release the slot; only the probe drives half-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `CircuitBreakerMiddleware`: a half-open probe that exited via a
+  non-triggering error (e.g. cancellation) left the probe slot claimed
+  forever, permanently rejecting all traffic; abandoned probes now release
+  the slot. Half-open transitions are now driven solely by the probe's
+  outcome — stale requests admitted before the circuit opened can no longer
+  close it, admit extra probes, or re-open it. ([#92])
+
 ## [0.5.3] - 2026-08-08
 
 ### Fixed
@@ -328,3 +336,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/gifton/PipelineKit/releases/tag/v0.2.0
 [#85]: https://github.com/gifton/PipelineKit/issues/85
 [#88]: https://github.com/gifton/PipelineKit/issues/88
+[#92]: https://github.com/gifton/PipelineKit/issues/92

--- a/Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift
@@ -48,7 +48,17 @@ public struct CircuitBreakerMiddleware: Middleware {
             case open(until: Date)
             case halfOpen
         }
-        
+
+        /// How `admitRequest()` classified a request.
+        enum Admission: Equatable {
+            case rejected
+            case normal
+            /// This request is the single half-open probe; its outcome — and only
+            /// its outcome — drives half-open state transitions, and `execute`
+            /// guarantees the probe slot is released on every exit path.
+            case probe
+        }
+
         #if canImport(os)
         private let lock = OSAllocatedUnfairLock()
         #else
@@ -66,8 +76,8 @@ public struct CircuitBreakerMiddleware: Middleware {
             self.configuration = configuration
         }
         
-        /// Check if a request should be allowed
-        func allowRequest() -> Bool {
+        /// Classify and admit/reject a request.
+        func admitRequest() -> Admission {
             lock.lock(); defer { lock.unlock() }
             switch state {
             case .closed:
@@ -77,28 +87,28 @@ public struct CircuitBreakerMiddleware: Middleware {
                     failureCount = 0
                     lastFailureTime = nil
                 }
-                return true
-                
+                return .normal
+
             case .open(let until):
                 if Date() >= until {
-                    // Transition to half-open
+                    // Transition to half-open; this request becomes the probe.
                     state = .halfOpen
                     halfOpenSuccessCount = 0
                     probeInProgress = true
-                    return true
+                    return .probe
                 }
-                return false
-                
+                return .rejected
+
             case .halfOpen:
                 // Only allow one probe request at a time
-                guard !probeInProgress else { return false }
+                guard !probeInProgress else { return .rejected }
                 probeInProgress = true
-                return true
+                return .probe
             }
         }
         
         /// Record a successful request
-        func recordSuccess() {
+        func recordSuccess(asProbe: Bool) {
             lock.lock(); defer { lock.unlock() }
             switch state {
             case .closed:
@@ -110,9 +120,10 @@ public struct CircuitBreakerMiddleware: Middleware {
                 break
                 
             case .halfOpen:
+                guard asProbe else { return }
                 halfOpenSuccessCount += 1
                 probeInProgress = false
-                
+
                 if halfOpenSuccessCount >= configuration.halfOpenSuccessThreshold {
                     // Transition to closed
                     state = .closed
@@ -122,12 +133,12 @@ public struct CircuitBreakerMiddleware: Middleware {
                 }
             }
         }
-        
+
         /// Record a failed request
-        func recordFailure() {
+        func recordFailure(asProbe: Bool) {
             lock.lock(); defer { lock.unlock() }
             let now = Date()
-            
+
             switch state {
             case .closed:
                 // Reset count if timeout expired
@@ -148,13 +159,24 @@ public struct CircuitBreakerMiddleware: Middleware {
                 state = .open(until: now.addingTimeInterval(configuration.recoveryTimeout))
                 
             case .halfOpen:
+                guard asProbe else { return }
                 // Single failure in half-open reopens the circuit
                 state = .open(until: now.addingTimeInterval(configuration.recoveryTimeout))
                 halfOpenSuccessCount = 0
                 probeInProgress = false
             }
         }
-        
+
+        /// Releases the probe slot when a probe exits without an outcome
+        /// (e.g. a cancelled or otherwise non-triggering error), so the next
+        /// request becomes the new probe instead of the breaker rejecting
+        /// traffic forever.
+        func abandonProbe() {
+            lock.lock(); defer { lock.unlock() }
+            guard case .halfOpen = state else { return }
+            probeInProgress = false
+        }
+
         /// Get current state for monitoring
         func getCurrentState() -> String {
             lock.lock(); defer { lock.unlock() }
@@ -244,9 +266,9 @@ public struct CircuitBreakerMiddleware: Middleware {
         next: @escaping MiddlewareNext<T>
     ) async throws -> T.Result {
         let commandType = String(describing: type(of: command))
-        
-        // Check if request is allowed
-        guard state.allowRequest() else {
+
+        let admission = state.admitRequest()
+        guard admission != .rejected else {
             // Circuit is open - fail fast
             throw PipelineError.middlewareError(
                 middleware: "CircuitBreakerMiddleware",
@@ -258,21 +280,27 @@ public struct CircuitBreakerMiddleware: Middleware {
                 )
             )
         }
-        
+
+        var outcomeRecorded = false
+        defer {
+            // A probe that exits without recording an outcome (non-triggering
+            // error, cancellation) must release the probe slot, or the breaker
+            // stays half-open and rejects all traffic forever.
+            if admission == .probe && !outcomeRecorded {
+                state.abandonProbe()
+            }
+        }
+
         do {
-            // Execute the command
             let result = try await next(command, context)
-            
-            // Record success
-            state.recordSuccess()
-            
+            outcomeRecorded = true
+            state.recordSuccess(asProbe: admission == .probe)
             return result
         } catch {
-            // Check if error should trigger circuit breaker
             if shouldTriggerCircuit(for: error) {
-                state.recordFailure()
+                outcomeRecorded = true
+                state.recordFailure(asProbe: admission == .probe)
             }
-            
             throw error
         }
     }

--- a/Tests/PipelineKitPerformanceTests/ActorVsLockBenchmark.swift
+++ b/Tests/PipelineKitPerformanceTests/ActorVsLockBenchmark.swift
@@ -6,7 +6,7 @@ import os
 
 /// Microbenchmark isolating the per-operation overhead of an `actor` vs a
 /// lock-protected `final class` for a trivial *synchronous* state mutation under
-/// heavy concurrency. This mirrors the shape of `CircuitBreaker.State.allowRequest`
+/// heavy concurrency. This mirrors the shape of `CircuitBreaker.State.admitRequest`
 /// (increment + threshold compare, no I/O) and is the gate for whether converting
 /// that internal actor to a lock is worth it.
 ///

--- a/Tests/PipelineKitResilienceTests/AuditCircuitBreakerProbeWedgeTests.swift
+++ b/Tests/PipelineKitResilienceTests/AuditCircuitBreakerProbeWedgeTests.swift
@@ -1,0 +1,114 @@
+//
+//  AuditCircuitBreakerProbeWedgeTests.swift
+//  PipelineKit
+//
+//  Audit evidence tests (2026-08): demonstrate a liveness defect found during the
+//  pre-integration audit.
+//
+//  Defect: when the single half-open probe request throws an error that
+//  `shouldTriggerCircuit` classifies as non-triggering (e.g. `CancellationError`,
+//  hardcoded to `false`), the breaker records neither success nor failure. The
+//  `probeInProgress` flag — set when the probe was admitted — is never cleared, and
+//  the `.halfOpen` branch of `allowRequest()` has no time-based escape. The breaker
+//  then rejects every subsequent request forever while reporting half-open.
+//
+//  `testWedge_...` PASSES while the defect exists (it pins the buggy behavior as
+//  evidence). When the defect is fixed, it will fail and should be replaced by the
+//  inverse assertion. `testControl_...` proves the harness itself is sound: absent
+//  an abandoned probe, the breaker recovers normally.
+//
+
+import XCTest
+@testable import PipelineKitCore
+import PipelineKitResilience
+
+private struct ProbeCommand: Command {
+    typealias Result = String
+}
+
+private enum GenericFailure: Error {
+    case boom // maps to `.unknown`, which the default configuration treats as triggering
+}
+
+final class AuditCircuitBreakerProbeWedgeTests: XCTestCase {
+    private func makeBreaker() -> CircuitBreakerMiddleware {
+        CircuitBreakerMiddleware(
+            configuration: CircuitBreakerMiddleware.Configuration(
+                failureThreshold: 1,
+                recoveryTimeout: 0.1, // clamped minimum
+                halfOpenSuccessThreshold: 1
+            )
+        )
+    }
+
+    private func trip(_ breaker: CircuitBreakerMiddleware) async {
+        do {
+            _ = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in
+                throw GenericFailure.boom
+            }
+            XCTFail("tripping call should rethrow")
+        } catch {
+            // expected: breaker records the failure and opens
+        }
+    }
+
+    /// Control: after the recovery timeout, a successful probe closes the circuit and
+    /// traffic flows again. Proves the fixture drives the breaker correctly.
+    func testControl_SuccessfulProbeClosesCircuitAfterRecoveryTimeout() async throws {
+        let breaker = makeBreaker()
+        await trip(breaker)
+
+        // While open, requests are rejected fast.
+        do {
+            _ = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "unreachable" }
+            XCTFail("open breaker should reject")
+        } catch { /* expected */ }
+
+        try await Task.sleep(nanoseconds: 200_000_000) // > recoveryTimeout
+
+        // Probe succeeds -> circuit closes.
+        let probeResult = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "probe-ok" }
+        XCTAssertEqual(probeResult, "probe-ok")
+
+        // Circuit closed: subsequent request flows immediately.
+        let after = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "closed-ok" }
+        XCTAssertEqual(after, "closed-ok")
+    }
+
+    /// Evidence of the defect: a probe abandoned via a non-triggering error
+    /// (CancellationError) wedges the breaker permanently — no amount of waiting
+    /// re-admits traffic.
+    func testWedge_AbandonedProbeRejectsAllTrafficForever_KnownDefect() async throws {
+        let breaker = makeBreaker()
+        await trip(breaker)
+
+        try await Task.sleep(nanoseconds: 200_000_000) // > recoveryTimeout
+
+        // The probe IS admitted (open -> halfOpen) — we observe its own error, not a
+        // fast-fail rejection — then aborts with a non-triggering error.
+        do {
+            _ = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in
+                throw CancellationError()
+            }
+            XCTFail("probe should rethrow its own error")
+        } catch is CancellationError {
+            // expected: admitted, then aborted; neither recordSuccess nor recordFailure ran
+        } catch {
+            XCTFail("probe was rejected instead of admitted: \(error)")
+        }
+
+        // From here on the breaker is wedged: every request is rejected no matter how
+        // long we wait (each wait is 2x the recovery timeout).
+        for round in 1...3 {
+            try await Task.sleep(nanoseconds: 200_000_000)
+            do {
+                _ = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "should-not-run" }
+                XCTFail("round \(round): breaker recovered — defect appears FIXED; " +
+                        "invert this test into a recovery assertion and delete the wedge pin")
+            } catch let error as PipelineError {
+                // expected: fast-fail rejection — the wedge persists
+                _ = error
+            }
+        }
+    }
+}

--- a/Tests/PipelineKitResilienceTests/AuditCircuitBreakerProbeWedgeTests.swift
+++ b/Tests/PipelineKitResilienceTests/AuditCircuitBreakerProbeWedgeTests.swift
@@ -2,20 +2,22 @@
 //  AuditCircuitBreakerProbeWedgeTests.swift
 //  PipelineKit
 //
-//  Audit evidence tests (2026-08): demonstrate a liveness defect found during the
-//  pre-integration audit.
+//  Audit evidence tests (2026-08): pin the fixed behavior for a liveness defect
+//  found during the pre-integration audit (#92).
 //
-//  Defect: when the single half-open probe request throws an error that
-//  `shouldTriggerCircuit` classifies as non-triggering (e.g. `CancellationError`,
-//  hardcoded to `false`), the breaker records neither success nor failure. The
-//  `probeInProgress` flag — set when the probe was admitted — is never cleared, and
-//  the `.halfOpen` branch of `allowRequest()` has no time-based escape. The breaker
-//  then rejects every subsequent request forever while reporting half-open.
+//  Former defect: when the single half-open probe request threw an error that
+//  `shouldTriggerCircuit` classified as non-triggering (e.g. `CancellationError`,
+//  hardcoded to `false`), the breaker recorded neither success nor failure. The
+//  `probeInProgress` flag — set when the probe was admitted — was never cleared, and
+//  the `.halfOpen` branch of `allowRequest()` had no time-based escape. The breaker
+//  then rejected every subsequent request forever while reporting half-open.
 //
-//  `testWedge_...` PASSES while the defect exists (it pins the buggy behavior as
-//  evidence). When the defect is fixed, it will fail and should be replaced by the
-//  inverse assertion. `testControl_...` proves the harness itself is sound: absent
-//  an abandoned probe, the breaker recovers normally.
+//  Fix: `State` now classifies admission via `admitRequest() -> Admission`, and
+//  `execute` guarantees resolution of an admitted probe — via `abandonProbe()` in a
+//  `defer` — on every exit path, including a non-triggering error. `testAbandoned...`
+//  pins that recovery: an abandoned probe releases its slot so the next request
+//  becomes the new probe and can close the circuit. `testControl_...` proves the
+//  harness itself is sound: absent an abandoned probe, the breaker recovers normally.
 //
 
 import XCTest
@@ -75,40 +77,32 @@ final class AuditCircuitBreakerProbeWedgeTests: XCTestCase {
         XCTAssertEqual(after, "closed-ok")
     }
 
-    /// Evidence of the defect: a probe abandoned via a non-triggering error
-    /// (CancellationError) wedges the breaker permanently — no amount of waiting
-    /// re-admits traffic.
-    func testWedge_AbandonedProbeRejectsAllTrafficForever_KnownDefect() async throws {
+    /// After the fix: a probe abandoned via a non-triggering error releases the
+    /// probe slot; the next request becomes the new probe and closes the circuit.
+    func testAbandonedProbeReleasesProbeSlot() async throws {
         let breaker = makeBreaker()
         await trip(breaker)
 
         try await Task.sleep(nanoseconds: 200_000_000) // > recoveryTimeout
 
-        // The probe IS admitted (open -> halfOpen) — we observe its own error, not a
-        // fast-fail rejection — then aborts with a non-triggering error.
+        // Probe admitted (open -> halfOpen), then abandoned without an outcome.
         do {
             _ = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in
                 throw CancellationError()
             }
             XCTFail("probe should rethrow its own error")
         } catch is CancellationError {
-            // expected: admitted, then aborted; neither recordSuccess nor recordFailure ran
+            // expected: admitted, then abandoned
         } catch {
             XCTFail("probe was rejected instead of admitted: \(error)")
         }
 
-        // From here on the breaker is wedged: every request is rejected no matter how
-        // long we wait (each wait is 2x the recovery timeout).
-        for round in 1...3 {
-            try await Task.sleep(nanoseconds: 200_000_000)
-            do {
-                _ = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "should-not-run" }
-                XCTFail("round \(round): breaker recovered — defect appears FIXED; " +
-                        "invert this test into a recovery assertion and delete the wedge pin")
-            } catch let error as PipelineError {
-                // expected: fast-fail rejection — the wedge persists
-                _ = error
-            }
-        }
+        // The abandoned probe released its slot: this request is admitted as
+        // the new probe and its success closes the circuit.
+        let recovered = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "recovered" }
+        XCTAssertEqual(recovered, "recovered")
+
+        let after = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "closed-ok" }
+        XCTAssertEqual(after, "closed-ok")
     }
 }

--- a/Tests/PipelineKitResilienceTests/CircuitBreakerProbeAccountingTests.swift
+++ b/Tests/PipelineKitResilienceTests/CircuitBreakerProbeAccountingTests.swift
@@ -1,0 +1,109 @@
+//
+//  CircuitBreakerProbeAccountingTests.swift
+//  PipelineKit
+//
+//  Half-open transitions must be driven solely by the probe's outcome.
+//  A stale request admitted while the circuit was CLOSED and completing
+//  during HALF-OPEN must not clear the probe slot, count toward
+//  halfOpenSuccessThreshold, or re-open the circuit.
+//
+
+import XCTest
+@testable import PipelineKitCore
+import PipelineKitResilience
+
+private struct AccountingCommand: Command {
+    typealias Result = String
+}
+
+private enum AccountingFailure: Error {
+    case boom // maps to `.unknown`, triggering under the default configuration
+}
+
+/// Minimal async gate: `wait()` suspends until `open()`; `open()` before
+/// `wait()` makes `wait()` return immediately.
+private actor Gate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var opened = false
+
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func open() {
+        opened = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+final class CircuitBreakerProbeAccountingTests: XCTestCase {
+    private func makeBreaker() -> CircuitBreakerMiddleware {
+        CircuitBreakerMiddleware(
+            configuration: CircuitBreakerMiddleware.Configuration(
+                failureThreshold: 1,
+                recoveryTimeout: 0.1, // clamped minimum
+                halfOpenSuccessThreshold: 1
+            )
+        )
+    }
+
+    func testStaleSuccessDuringHalfOpenDoesNotDriveProbeAccounting() async throws {
+        let breaker = makeBreaker()
+        let staleEntered = Gate(), staleRelease = Gate()
+        let probeEntered = Gate(), probeRelease = Gate()
+
+        // R1: admitted while CLOSED, parks inside the chain.
+        let stale = Task {
+            try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in
+                await staleEntered.open()
+                await staleRelease.wait()
+                return "stale-ok"
+            }
+        }
+        await staleEntered.wait()
+
+        // Trip the breaker -> OPEN.
+        do {
+            _ = try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in
+                throw AccountingFailure.boom
+            }
+            XCTFail("tripping call should rethrow")
+        } catch { /* expected */ }
+
+        try await Task.sleep(nanoseconds: 200_000_000) // > recoveryTimeout
+
+        // R2: admitted as the half-open probe, parks inside the chain.
+        let probe = Task {
+            try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in
+                await probeEntered.open()
+                await probeRelease.wait()
+                return "probe-ok"
+            }
+        }
+        await probeEntered.wait()
+
+        // The stale closed-era request completes successfully DURING half-open.
+        await staleRelease.open()
+        let staleResult = try await stale.value
+        XCTAssertEqual(staleResult, "stale-ok")
+
+        // Stale success must not close the circuit or free the probe slot:
+        // while the real probe is still in flight, new traffic stays rejected.
+        do {
+            _ = try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in "should-not-run" }
+            XCTFail("stale success drove half-open accounting: traffic admitted while the probe was still in flight")
+        } catch let error as PipelineError {
+            _ = error // expected fast-fail rejection
+        }
+
+        // The real probe's success closes the circuit.
+        await probeRelease.open()
+        let probeResult = try await probe.value
+        XCTAssertEqual(probeResult, "probe-ok")
+
+        let after = try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in "closed-ok" }
+        XCTAssertEqual(after, "closed-ok")
+    }
+}

--- a/docs/superpowers/plans/2026-08-13-release-0.5.4-audit-fixes.md
+++ b/docs/superpowers/plans/2026-08-13-release-0.5.4-audit-fixes.md
@@ -1,0 +1,987 @@
+# Release 0.5.4 Audit Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the patch-safe audit remediations (circuit-breaker probe lifecycle, NextGuard warning suppression, `maxBorrowPercentage` rename, `.tagged` deprecation, auth-docs truth) as three PRs ready for a 0.5.4 tag.
+
+**Architecture:** One runtime fix (a private state-machine change in `CircuitBreakerMiddleware` introducing admission roles + guaranteed probe resolution) plus declaration-line marker conformances and additive/deprecating API polish. No public behavior changes outside the fixed defect.
+
+**Tech Stack:** Swift 6.2, SwiftPM, XCTest, `gh` CLI. Strict concurrency + `ExistentialAny` are on: write `any Protocol` for existentials.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-release-0.5.4-audit-fixes-design.md`
+
+## Global Constraints
+
+- Patch release rules (VERSIONING.md): no source breaks, no documented-behavior changes; deprecations and additive API allowed.
+- Every user-visible change gets a CHANGELOG entry under `## [Unreleased]` (Keep-a-Changelog categories: `### Fixed`, `### Deprecated`, `### Changed`).
+- Commits end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`; PR bodies end with: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- Test loop: `swift test --filter "<Suite>"` for the task's suite, then `swift test --parallel --skip PipelineKitPerformanceTests` before opening each PR. If a test crashes inexplicably after an incremental build: `rm -rf .build` first.
+- The full unfiltered suite in Xcode is the maintainer's pre-merge gate — do not merge PRs; leave them open.
+- Existing audit evidence tests live on branch `audit/verification-tests` @ `96853c8` (two files). PR 1 takes `AuditCircuitBreakerProbeWedgeTests.swift`; PR 2 takes `AuditRetryThroughGuardedChainTests.swift`. Cherry-pick per-file with `git checkout audit/verification-tests -- <path>`.
+
+---
+
+### Task 1: PR 1 setup — branch, docs, defect issue
+
+**Files:**
+- Commit (already on disk, untracked): `docs/superpowers/specs/2026-08-13-release-0.5.4-audit-fixes-design.md`, `docs/superpowers/plans/2026-08-13-release-0.5.4-audit-fixes.md`
+
+**Interfaces:**
+- Produces: branch `fix/circuit-breaker-probe-lifecycle`; environment note `ISSUE_PROBE=<number>` used by Tasks 4–5 in CHANGELOG/PR text.
+
+- [ ] **Step 1: Branch from main**
+
+```bash
+git checkout main && git pull && git checkout -b fix/circuit-breaker-probe-lifecycle
+```
+
+- [ ] **Step 2: Commit spec + plan**
+
+```bash
+git add docs/superpowers/specs/2026-08-13-release-0.5.4-audit-fixes-design.md docs/superpowers/plans/2026-08-13-release-0.5.4-audit-fixes.md
+git commit -m "docs(spec+plan): release 0.5.4 audit fixes — probe lifecycle, warning suppression, API polish
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: File the probe-lifecycle issue**
+
+```bash
+gh issue create \
+  --title "CircuitBreakerMiddleware: abandoned half-open probe wedges the breaker permanently; stale requests corrupt half-open accounting" \
+  --body "$(cat <<'EOF'
+Found by the 2026-08 pre-integration audit (findings F-17/F-18).
+
+**F-17 (liveness, high severity).** When the single half-open probe throws an error that `shouldTriggerCircuit` classifies as non-triggering — `CancellationError` is hardcoded to `false` (`CircuitBreakerMiddleware.swift:296`), as is any type outside `triggeredByErrors` — the catch block records neither success nor failure (`:270-277`). `probeInProgress` was set at admission (`:87`/`:95`) and is only cleared by `recordSuccess`/`recordFailure`; the `.halfOpen` branch of `allowRequest()` has no time-based escape (`:94`). The breaker then rejects every request forever. One cancelled probe Task converts "fail fast temporarily" into a permanent outage of the guarded route. Demonstrated deterministically by `AuditCircuitBreakerProbeWedgeTests` (branch `audit/verification-tests`).
+
+**F-18 (correctness under contention).** Any request completing during `.halfOpen` drives probe accounting: a stale closed-era success clears `probeInProgress` and counts toward `halfOpenSuccessThreshold` (`:112-118`), so pre-outage traffic can admit extra probes and close the circuit.
+
+**Fix (one mechanism):** admission roles — `allowRequest()` returns whether this request is the probe; only the probe's outcome drives half-open transitions; a `defer` in `execute` abandons an unresolved probe so the slot is always released.
+EOF
+)"
+```
+
+Record the created issue number as `ISSUE_PROBE` for later steps.
+
+- [ ] **Step 4: Cherry-pick the audit wedge tests and verify current behavior**
+
+```bash
+git checkout audit/verification-tests -- Tests/PipelineKitResilienceTests/AuditCircuitBreakerProbeWedgeTests.swift
+swift test --filter AuditCircuitBreakerProbeWedgeTests
+```
+
+Expected: BOTH tests pass — the control test proves recovery works absent the defect; the wedge pin passes *because the defect exists*.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Tests/PipelineKitResilienceTests/AuditCircuitBreakerProbeWedgeTests.swift
+git commit -m "test(resilience): land audit evidence — circuit-breaker probe wedge pin + recovery control (#$ISSUE_PROBE)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Failing test for stale half-open attribution (F-18)
+
+**Files:**
+- Create: `Tests/PipelineKitResilienceTests/CircuitBreakerProbeAccountingTests.swift`
+
+**Interfaces:**
+- Consumes: `CircuitBreakerMiddleware(configuration:)`, `CommandContext()`, `PipelineError` (all existing).
+- Produces: the red test Task 3 turns green. File-private fixtures only.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+//
+//  CircuitBreakerProbeAccountingTests.swift
+//  PipelineKit
+//
+//  Half-open transitions must be driven solely by the probe's outcome.
+//  A stale request admitted while the circuit was CLOSED and completing
+//  during HALF-OPEN must not clear the probe slot, count toward
+//  halfOpenSuccessThreshold, or re-open the circuit.
+//
+
+import XCTest
+@testable import PipelineKitCore
+import PipelineKitResilience
+
+private struct AccountingCommand: Command {
+    typealias Result = String
+}
+
+private enum AccountingFailure: Error {
+    case boom // maps to `.unknown`, triggering under the default configuration
+}
+
+/// Minimal async gate: `wait()` suspends until `open()`; `open()` before
+/// `wait()` makes `wait()` return immediately.
+private actor Gate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var opened = false
+
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func open() {
+        opened = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+final class CircuitBreakerProbeAccountingTests: XCTestCase {
+    private func makeBreaker() -> CircuitBreakerMiddleware {
+        CircuitBreakerMiddleware(
+            configuration: CircuitBreakerMiddleware.Configuration(
+                failureThreshold: 1,
+                recoveryTimeout: 0.1, // clamped minimum
+                halfOpenSuccessThreshold: 1
+            )
+        )
+    }
+
+    func testStaleSuccessDuringHalfOpenDoesNotDriveProbeAccounting() async throws {
+        let breaker = makeBreaker()
+        let staleEntered = Gate(), staleRelease = Gate()
+        let probeEntered = Gate(), probeRelease = Gate()
+
+        // R1: admitted while CLOSED, parks inside the chain.
+        let stale = Task {
+            try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in
+                await staleEntered.open()
+                await staleRelease.wait()
+                return "stale-ok"
+            }
+        }
+        await staleEntered.wait()
+
+        // Trip the breaker -> OPEN.
+        do {
+            _ = try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in
+                throw AccountingFailure.boom
+            }
+            XCTFail("tripping call should rethrow")
+        } catch { /* expected */ }
+
+        try await Task.sleep(nanoseconds: 200_000_000) // > recoveryTimeout
+
+        // R2: admitted as the half-open probe, parks inside the chain.
+        let probe = Task {
+            try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in
+                await probeEntered.open()
+                await probeRelease.wait()
+                return "probe-ok"
+            }
+        }
+        await probeEntered.wait()
+
+        // The stale closed-era request completes successfully DURING half-open.
+        await staleRelease.open()
+        let staleResult = try await stale.value
+        XCTAssertEqual(staleResult, "stale-ok")
+
+        // Stale success must not close the circuit or free the probe slot:
+        // while the real probe is still in flight, new traffic stays rejected.
+        do {
+            _ = try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in "should-not-run" }
+            XCTFail("stale success drove half-open accounting: traffic admitted while the probe was still in flight")
+        } catch let error as PipelineError {
+            _ = error // expected fast-fail rejection
+        }
+
+        // The real probe's success closes the circuit.
+        await probeRelease.open()
+        let probeResult = try await probe.value
+        XCTAssertEqual(probeResult, "probe-ok")
+
+        let after = try await breaker.execute(AccountingCommand(), context: CommandContext()) { _, _ in "closed-ok" }
+        XCTAssertEqual(after, "closed-ok")
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails on current code**
+
+```bash
+swift test --filter CircuitBreakerProbeAccountingTests
+```
+
+Expected: FAIL at "stale success drove half-open accounting" — current `recordSuccess` clears `probeInProgress` and closes the circuit on the stale result.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add Tests/PipelineKitResilienceTests/CircuitBreakerProbeAccountingTests.swift
+git commit -m "test(resilience): red — stale success during half-open must not drive probe accounting (#$ISSUE_PROBE)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Probe lifecycle fix — admission roles + guaranteed resolution
+
+**Files:**
+- Modify: `Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift` (State class ~lines 45–167; `execute` ~lines 240–277)
+
+**Interfaces:**
+- Consumes: nothing new. `State` is `private`; no public API changes.
+- Produces: `State.admitRequest() -> Admission`, `recordSuccess(asProbe:)`, `recordFailure(asProbe:)`, `abandonProbe()`. Task 4 relies on the fixed behavior only.
+
+- [ ] **Step 1: Add the Admission enum inside `State` (below `enum CircuitState`)**
+
+```swift
+        /// How `admitRequest()` classified a request.
+        enum Admission: Equatable {
+            case rejected
+            case normal
+            /// This request is the single half-open probe; its outcome — and only
+            /// its outcome — drives half-open state transitions, and `execute`
+            /// guarantees the probe slot is released on every exit path.
+            case probe
+        }
+```
+
+- [ ] **Step 2: Replace `allowRequest()` with `admitRequest()`**
+
+Same body and locking; the open→half-open transition and the half-open admission return `.probe`, `.closed` returns `.normal`, rejections return `.rejected`:
+
+```swift
+        /// Classify and admit/reject a request.
+        func admitRequest() -> Admission {
+            lock.lock(); defer { lock.unlock() }
+            switch state {
+            case .closed:
+                // Reset failure count if enough time has passed
+                if let lastFailure = lastFailureTime,
+                   Date().timeIntervalSince(lastFailure) >= configuration.resetTimeout {
+                    failureCount = 0
+                    lastFailureTime = nil
+                }
+                return .normal
+
+            case .open(let until):
+                if Date() >= until {
+                    // Transition to half-open; this request becomes the probe.
+                    state = .halfOpen
+                    halfOpenSuccessCount = 0
+                    probeInProgress = true
+                    return .probe
+                }
+                return .rejected
+
+            case .halfOpen:
+                // Only allow one probe request at a time
+                guard !probeInProgress else { return .rejected }
+                probeInProgress = true
+                return .probe
+            }
+        }
+```
+
+- [ ] **Step 3: Make the record methods probe-aware and add `abandonProbe()`**
+
+`recordSuccess`/`recordFailure` gain an `asProbe: Bool` parameter. The `.closed` and `.open` branches are byte-for-byte unchanged; each `.halfOpen` branch gains a leading `guard asProbe else { return }` (half-open transitions are driven solely by the probe — stale closed-era outcomes are ignored). Then add:
+
+```swift
+        /// Releases the probe slot when a probe exits without an outcome
+        /// (e.g. a cancelled or otherwise non-triggering error), so the next
+        /// request becomes the new probe instead of the breaker rejecting
+        /// traffic forever.
+        func abandonProbe() {
+            lock.lock(); defer { lock.unlock() }
+            guard case .halfOpen = state else { return }
+            probeInProgress = false
+        }
+```
+
+- [ ] **Step 4: Rewrite the admission/outcome section of `execute`**
+
+Replace the `guard state.allowRequest() else { ... }` block and the `do/catch` (keep the existing thrown `PipelineError.middlewareError(...)` rejection expression exactly as it is):
+
+```swift
+        let admission = state.admitRequest()
+        guard admission != .rejected else {
+            // Circuit is open - fail fast
+            throw PipelineError.middlewareError(
+                middleware: "CircuitBreakerMiddleware",
+                message: "Circuit breaker is open - request rejected",
+                context: PipelineError.ErrorContext(
+                    commandType: commandType,
+                    middlewareType: "CircuitBreakerMiddleware",
+                    additionalInfo: ["state": "open"]
+                )
+            )
+        }
+
+        var outcomeRecorded = false
+        defer {
+            // A probe that exits without recording an outcome (non-triggering
+            // error, cancellation) must release the probe slot, or the breaker
+            // stays half-open and rejects all traffic forever.
+            if admission == .probe && !outcomeRecorded {
+                state.abandonProbe()
+            }
+        }
+
+        do {
+            let result = try await next(command, context)
+            outcomeRecorded = true
+            state.recordSuccess(asProbe: admission == .probe)
+            return result
+        } catch {
+            if shouldTriggerCircuit(for: error) {
+                outcomeRecorded = true
+                state.recordFailure(asProbe: admission == .probe)
+            }
+            throw error
+        }
+```
+
+(The `outcomeRecorded` flag matters: after a resolved probe, another task may already have been admitted as the *next* probe; an unconditional defer would clear that probe's slot.)
+
+- [ ] **Step 5: Run the breaker suites**
+
+```bash
+swift test --filter "CircuitBreakerProbeAccountingTests|CircuitBreakerMiddlewareTests|CircuitBreakerStateConcurrencyTests|AuditCircuitBreakerProbeWedgeTests"
+```
+
+Expected: `CircuitBreakerProbeAccountingTests` PASSES now. `AuditCircuitBreakerProbeWedgeTests.testWedge_...` FAILS with its built-in message "breaker recovered — defect appears FIXED; invert this test" — that failure is the plan working. Control test and the two pre-existing breaker suites PASS (they don't rely on stale-attribution behavior; if any test asserts the old stale semantics, stop and re-read it — do not weaken the fix to satisfy a test that pins the bug).
+
+- [ ] **Step 6: Invert the wedge pin into a recovery assertion**
+
+In `AuditCircuitBreakerProbeWedgeTests.swift`, replace the whole `testWedge_AbandonedProbeRejectsAllTrafficForever_KnownDefect` method with:
+
+```swift
+    /// After the fix: a probe abandoned via a non-triggering error releases the
+    /// probe slot; the next request becomes the new probe and closes the circuit.
+    func testAbandonedProbeReleasesProbeSlot() async throws {
+        let breaker = makeBreaker()
+        await trip(breaker)
+
+        try await Task.sleep(nanoseconds: 200_000_000) // > recoveryTimeout
+
+        // Probe admitted (open -> halfOpen), then abandoned without an outcome.
+        do {
+            _ = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in
+                throw CancellationError()
+            }
+            XCTFail("probe should rethrow its own error")
+        } catch is CancellationError {
+            // expected: admitted, then abandoned
+        } catch {
+            XCTFail("probe was rejected instead of admitted: \(error)")
+        }
+
+        // The abandoned probe released its slot: this request is admitted as
+        // the new probe and its success closes the circuit.
+        let recovered = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "recovered" }
+        XCTAssertEqual(recovered, "recovered")
+
+        let after = try await breaker.execute(ProbeCommand(), context: CommandContext()) { _, _ in "closed-ok" }
+        XCTAssertEqual(after, "closed-ok")
+    }
+```
+
+Also update the file's header comment: it documents evidence of a defect; rewrite the paragraph to say the file now pins the fixed behavior (probe abandonment releases the slot) alongside the recovery control test.
+
+- [ ] **Step 7: Run the four suites again**
+
+```bash
+swift test --filter "CircuitBreakerProbeAccountingTests|CircuitBreakerMiddlewareTests|CircuitBreakerStateConcurrencyTests|AuditCircuitBreakerProbeWedgeTests"
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift Tests/PipelineKitResilienceTests/AuditCircuitBreakerProbeWedgeTests.swift
+git commit -m "fix(resilience): circuit breaker releases abandoned probes; only the probe drives half-open (#$ISSUE_PROBE)
+
+allowRequest() -> admitRequest() -> Admission so execute knows whether this
+request is the half-open probe. A defer abandons an unresolved probe
+(non-triggering error, cancellation), releasing the slot instead of wedging
+the breaker in permanent rejection. recordSuccess/recordFailure ignore
+non-probe outcomes in half-open, so stale closed-era traffic can no longer
+clear the probe slot, count toward the close threshold, or re-open the
+circuit.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: PR 1 — CHANGELOG, full filtered suite, open PR
+
+**Files:**
+- Modify: `CHANGELOG.md` (top of `## [Unreleased]`)
+
+- [ ] **Step 1: CHANGELOG entry**
+
+Under `## [Unreleased]` add:
+
+```markdown
+### Fixed
+- `CircuitBreakerMiddleware`: a half-open probe that exited via a
+  non-triggering error (e.g. cancellation) left the probe slot claimed
+  forever, permanently rejecting all traffic; abandoned probes now release
+  the slot. Half-open transitions are now driven solely by the probe's
+  outcome — stale requests admitted before the circuit opened can no longer
+  close it, admit extra probes, or re-open it. ([#ISSUE_PROBE])
+```
+
+(Replace `ISSUE_PROBE` with the real number, and add the reference link line at the bottom of the file following the existing `[#85]:` pattern.)
+
+- [ ] **Step 2: Full filtered suite**
+
+```bash
+swift test --parallel --skip PipelineKitPerformanceTests
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Commit + push + open PR (leave open, do not merge)**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: CHANGELOG for circuit-breaker probe lifecycle fix (#$ISSUE_PROBE)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin fix/circuit-breaker-probe-lifecycle
+gh pr create --title "fix(resilience): circuit breaker probe lifecycle — abandoned probes release the slot; only the probe drives half-open" --body "$(cat <<EOF
+Fixes #$ISSUE_PROBE (audit findings F-17/F-18).
+
+- \`admitRequest() -> Admission\` (private): execute knows whether this request is the half-open probe.
+- \`defer\`-guaranteed probe resolution: a probe exiting via a non-triggering error abandons the slot instead of wedging the breaker permanently.
+- Half-open transitions driven solely by the probe's outcome; stale closed-era requests are ignored.
+- Evidence: audit wedge test inverted into a recovery assertion; new deterministic stale-attribution test with async gates.
+
+No public API or configuration changes; \`State\` is private.
+
+Maintainer gate: full unfiltered suite in Xcode before merge.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Task 5: PR 2 — NextGuard warning suppression + retry evidence tests
+
+**Files:**
+- Modify (append `, NextGuardWarningSuppressing` to the type's protocol list on the declaration line):
+  - `Sources/PipelineKitResilienceCore/BackPressureMiddleware.swift:7` — `public actor BackPressureMiddleware: Middleware {`
+  - `Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift:33` — `public struct CircuitBreakerMiddleware: Middleware {`
+  - `Sources/PipelineKitResilienceRateLimiting/RateLimitingMiddleware.swift:14`
+  - `Sources/PipelineKitResilienceRateLimiting/EnhancedRateLimitingMiddleware.swift:28`
+  - `Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift:60`
+  - `Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift:34`
+  - `Sources/PipelineKitResilienceCircuitBreaker/HealthCheckMiddleware.swift:33`
+  - `Sources/PipelineKitSecurity/Middleware/Validation/ValidationMiddleware.swift:24`
+  - `Sources/PipelineKitSecurity/Policies/SecurityPolicy.swift:72` (`SecurityPolicyMiddleware`)
+  - `Examples/Sources/AdvancedExample/main.swift` — `OrderValidationMiddleware` declaration
+- Create: `Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift`
+- Create: `Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift`
+- Cherry-pick: `Tests/PipelineKitResilienceTests/AuditRetryThroughGuardedChainTests.swift` from `audit/verification-tests`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: `public protocol NextGuardWarningSuppressing: Middleware` (marker, `Sources/PipelineKitCore/Middleware/Middleware.swift:231`), re-exported through `PipelineKit`; conformance-line precedent: `AuthorizationMiddleware.swift:9`.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Branch from main**
+
+```bash
+git checkout main && git checkout -b chore/nextguard-warning-suppression
+```
+
+- [ ] **Step 2: Cherry-pick the retry evidence tests, verify green**
+
+```bash
+git checkout audit/verification-tests -- Tests/PipelineKitResilienceTests/AuditRetryThroughGuardedChainTests.swift
+swift test --filter AuditRetryThroughGuardedChainTests
+```
+
+Expected: 3 tests PASS (they pin already-correct behavior: a retry's second attempt traverses guarded middleware with fresh NextGuards).
+
+- [ ] **Step 3: Write the failing conformance tests**
+
+`Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift`:
+
+```swift
+//
+//  NextGuardSuppressionConformanceTests.swift
+//  PipelineKit
+//
+//  Middlewares that intentionally short-circuit (throw a rejection or return
+//  without calling next) must conform to NextGuardWarningSuppressing so their
+//  normal rejection paths don't emit false debug "deallocated without calling
+//  next()" warnings. Metatype assertions pin the contract without needing to
+//  construct configurations.
+//
+
+import XCTest
+import PipelineKitCore
+import PipelineKitResilience
+
+final class NextGuardSuppressionConformanceTests: XCTestCase {
+    func testShortCircuitingResilienceMiddlewaresSuppressNextGuardWarnings() {
+        XCTAssertTrue(BackPressureMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(CircuitBreakerMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(RateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(EnhancedRateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(BulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(PartitionedBulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(HealthCheckMiddleware.self is any NextGuardWarningSuppressing.Type)
+    }
+}
+```
+
+`Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift`:
+
+```swift
+import XCTest
+import PipelineKitCore
+import PipelineKitSecurity
+
+final class NextGuardSuppressionConformanceTests: XCTestCase {
+    func testShortCircuitingSecurityMiddlewaresSuppressNextGuardWarnings() {
+        XCTAssertTrue(ValidationMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(SecurityPolicyMiddleware.self is any NextGuardWarningSuppressing.Type)
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify both fail**
+
+```bash
+swift test --filter NextGuardSuppressionConformanceTests
+```
+
+Expected: FAIL — 9 assertion failures (none of the types conform yet).
+
+- [ ] **Step 5: Add the nine conformances**
+
+On each declaration line listed in **Files**, append the marker after `Middleware`, e.g.:
+
+```swift
+public struct CircuitBreakerMiddleware: Middleware, NextGuardWarningSuppressing {
+```
+
+```swift
+public actor BackPressureMiddleware: Middleware, NextGuardWarningSuppressing {
+```
+
+Also conform the example's middleware in `Examples/Sources/AdvancedExample/main.swift` (it currently prints the false warning on the demo's rejection path):
+
+```swift
+struct OrderValidationMiddleware: Middleware, NextGuardWarningSuppressing {
+```
+
+(Match the example's actual declaration line; only the protocol list changes.)
+
+- [ ] **Step 6: Run tests + example**
+
+```bash
+swift test --filter "NextGuardSuppressionConformanceTests|AuditRetryThroughGuardedChainTests"
+swift build --package-path Examples && Examples/.build/debug/AdvancedExample
+```
+
+Expected: tests PASS; AdvancedExample output no longer contains "⚠️ WARNING: NextGuard(OrderValidationMiddleware)".
+
+- [ ] **Step 7: CHANGELOG entry**
+
+Under `## [Unreleased]` `### Fixed`:
+
+```markdown
+- Rejection paths of `BackPressureMiddleware`, `CircuitBreakerMiddleware`,
+  `RateLimitingMiddleware`, `EnhancedRateLimitingMiddleware`,
+  `BulkheadMiddleware`, `PartitionedBulkheadMiddleware`,
+  `HealthCheckMiddleware`, `ValidationMiddleware`, and
+  `SecurityPolicyMiddleware` no longer emit false debug
+  "NextGuard deallocated without calling next()" warnings: all nine now
+  conform to `NextGuardWarningSuppressing`, matching the caching and auth
+  middlewares.
+```
+
+- [ ] **Step 8: Full filtered suite, commit, push, open PR (leave open)**
+
+```bash
+swift test --parallel --skip PipelineKitPerformanceTests
+git add -A
+git commit -m "fix(middleware): suppress false NextGuard deinit warnings on intentional short-circuits
+
+Nine shipped middlewares reject by throwing (or, for BulkheadMiddleware's
+fallback/custom policies, return without calling next) and warned on every
+normal rejection in debug builds. Conform them to
+NextGuardWarningSuppressing, matching the existing caching/auth precedent.
+Also lands the audit's retry-through-guarded-chain evidence tests, closing
+the coverage gap where no test drove a real second retry attempt through a
+guarded downstream middleware.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin chore/nextguard-warning-suppression
+gh pr create --title "fix(middleware): suppress false NextGuard warnings on short-circuit paths; land retry evidence tests" --body "$(cat <<'EOF'
+Audit findings F-04/F-12 (+ retry evidence tests from F-10/F-11).
+
+- Nine short-circuiting middlewares conform to `NextGuardWarningSuppressing` (debug-only diagnostics; zero runtime change).
+- `AdvancedExample` no longer prints the false warning on its demo rejection path.
+- New conformance-assertion tests pin the contract; audit retry tests pin fresh-guard-per-attempt through StandardPipeline, ResilientMiddleware, and DynamicPipeline's retryPolicy loop.
+
+Maintainer gate: full unfiltered suite in Xcode before merge.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Task 6: PR 3 (part 1) — rename `maxBorrowPercentage` → `reservedCapacityPercentage`
+
+**Files:**
+- Modify: `Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift` (Configuration property :107–118, init :127–155, doc mentions :182 and :218, borrow math :492–495)
+- Create: `Tests/PipelineKitResilienceTests/PartitionedBulkheadConfigurationTests.swift`
+
+**Interfaces:**
+- Produces: `Configuration.reservedCapacityPercentage: Double` (stored, default 0.2); `Configuration.maxBorrowPercentage` (deprecated computed alias); deprecated init overload with required `maxBorrowPercentage:` label. Task 8's CHANGELOG references these names.
+
+- [ ] **Step 1: Branch from main**
+
+```bash
+git checkout main && git checkout -b chore/api-docs-polish-0.5.4
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```swift
+//
+//  PartitionedBulkheadConfigurationTests.swift
+//  PipelineKit
+//
+//  reservedCapacityPercentage is the truthful name for the value historically
+//  exposed as maxBorrowPercentage (which was always the lender's RESERVED
+//  share, not a borrowing cap). The old name and init survive as deprecated
+//  forwarding shims until 0.6.
+//
+
+import XCTest
+@testable import PipelineKitCore
+import PipelineKitResilience
+
+final class PartitionedBulkheadConfigurationTests: XCTestCase {
+    private static let partitions = [
+        "default": PartitionedBulkheadMiddleware.PartitionConfig(capacity: 10)
+    ]
+
+    func testReservedCapacityPercentageIsPrimaryAndDefaultsUnchanged() {
+        let config = PartitionedBulkheadMiddleware.Configuration(
+            partitions: Self.partitions,
+            partitionExtractor: { _, _ in "default" }
+        )
+        XCTAssertEqual(config.reservedCapacityPercentage, 0.2, accuracy: .ulpOfOne)
+    }
+
+    func testDeprecatedAliasAndInitForwardToReservedCapacityPercentage() {
+        let config = PartitionedBulkheadMiddleware.Configuration(
+            partitions: Self.partitions,
+            partitionExtractor: { _, _ in "default" },
+            reservedCapacityPercentage: 0.5
+        )
+        // Deprecation warnings below are expected: the test pins the shims.
+        XCTAssertEqual(config.maxBorrowPercentage, 0.5, accuracy: .ulpOfOne)
+
+        let legacy = PartitionedBulkheadMiddleware.Configuration(
+            partitions: Self.partitions,
+            partitionExtractor: { _, _ in "default" },
+            maxBorrowPercentage: 0.3
+        )
+        XCTAssertEqual(legacy.reservedCapacityPercentage, 0.3, accuracy: .ulpOfOne)
+    }
+}
+```
+
+(If `PartitionConfig`'s initializer differs from `PartitionConfig(capacity: 10)`, read its declaration in the same source file and use the minimal valid form — do not add parameters to the fixture beyond capacity.)
+
+- [ ] **Step 3: Run to verify it fails**
+
+```bash
+swift test --filter PartitionedBulkheadConfigurationTests
+```
+
+Expected: FAIL to compile — `reservedCapacityPercentage` doesn't exist yet.
+
+- [ ] **Step 4: Implement the rename with deprecated shims**
+
+Replace the stored property (:107–118) with:
+
+```swift
+        /// The fraction (`0.0`–`1.0`) of a lending partition's capacity that is
+        /// reserved for that partition's own commands and never lent out.
+        ///
+        /// With the default `0.2`, up to ~80% of an otherwise-idle partition's
+        /// capacity can be lent to other partitions.
+        public let reservedCapacityPercentage: Double
+
+        /// Deprecated alias for ``reservedCapacityPercentage``.
+        ///
+        /// Despite the historical name, this value has always been the lender's
+        /// *reserved* (non-lendable) share, not a borrowing cap — renamed to say
+        /// what it does. The semantics are unchanged.
+        @available(*, deprecated, renamed: "reservedCapacityPercentage")
+        public var maxBorrowPercentage: Double { reservedCapacityPercentage }
+```
+
+In the primary init, rename the parameter to `reservedCapacityPercentage: Double = 0.2` (keep position and doc comment, updating its text to the reserved-share phrasing) and assign `self.reservedCapacityPercentage = reservedCapacityPercentage`. Then add the deprecated overload directly after it — the `maxBorrowPercentage:` label has **no default**, so unlabeled calls resolve unambiguously to the primary init:
+
+```swift
+        /// Deprecated: use `init(partitions:partitionExtractor:defaultPartition:allowBorrowing:reservedCapacityPercentage:emitMetrics:)`.
+        @available(*, deprecated, message: "maxBorrowPercentage has always been the reserved (non-lendable) share — use reservedCapacityPercentage, which has identical semantics.")
+        public init(
+            partitions: [String: PartitionConfig],
+            partitionExtractor: @escaping @Sendable (any Command, CommandContext) async -> String,
+            defaultPartition: String = "default",
+            allowBorrowing: Bool = true,
+            maxBorrowPercentage: Double,
+            emitMetrics: Bool = true
+        ) {
+            self.init(
+                partitions: partitions,
+                partitionExtractor: partitionExtractor,
+                defaultPartition: defaultPartition,
+                allowBorrowing: allowBorrowing,
+                reservedCapacityPercentage: maxBorrowPercentage,
+                emitMetrics: emitMetrics
+            )
+        }
+```
+
+Update the borrow math (:492–495) to the truthful local name:
+
+```swift
+                let reservedCapacity = Int(Double(stats.capacity) * configuration.reservedCapacityPercentage)
+                let availableForBorrowing = stats.capacity - stats.activeCount - reservedCapacity
+```
+
+Update the two remaining doc mentions (`:182` default-summary and `:218` borrowing explanation) to say `reservedCapacityPercentage`.
+
+- [ ] **Step 5: Run and verify**
+
+```bash
+swift test --filter "PartitionedBulkheadConfigurationTests|PartitionedBulkheadMiddlewareTests"
+```
+
+Expected: PASS (deprecation warnings in the alias test are expected). Build must show no *errors*; the only new warnings are the intentional deprecations in the test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift Tests/PipelineKitResilienceTests/PartitionedBulkheadConfigurationTests.swift
+git commit -m "refactor(resilience): rename maxBorrowPercentage to reservedCapacityPercentage (deprecated alias kept)
+
+The value has always been the lender's reserved share — 0.2 meant up to
+~80% lendable, the near-opposite of the name. Semantics unchanged; old
+property and init survive as deprecated forwarding shims until 0.6.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: PR 3 (part 2) — deprecate `.tagged` isolation mode
+
+**Files:**
+- Modify: `Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift` (case :130, dispatch match ~:193, `executeTaggedIsolation` doc ~:337)
+- Modify: `docs/guides/resilience-patterns.md` (tagged caveat sections, ~:112–118 and ~:286–292)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: deprecated `IsolationMode.tagged`; Task 8's CHANGELOG + PR close #86.
+
+- [ ] **Step 1: Deprecate the case**
+
+```swift
+        /// Use tagged isolation for different command types.
+        @available(*, deprecated, message: "Tagged mode never provided per-tag isolation — every tag contends on the same shared semaphore, and the tag is recorded only as context metadata (#86). For real per-tenant capacity use PartitionedBulkheadMiddleware with allowBorrowing: false. This mode will be removed in 0.6.")
+        case tagged(keyExtractor: @Sendable (any Command) -> String)
+```
+
+- [ ] **Step 2: Annotate the intentional internal warning**
+
+Directly above `case let .tagged(keyExtractor):` in `execute`'s switch, add:
+
+```swift
+        // Deprecation warning on this match is expected and accepted: the case
+        // stays functional until its removal in 0.6.
+```
+
+- [ ] **Step 3: Build and check the warning budget**
+
+```bash
+swift build 2>&1 | grep -c "deprecated"
+```
+
+Expected: exactly the intentional occurrences (the `execute` match, and `executeTaggedIsolation` if it references the case). Any *other* new deprecation warning means a stray usage — fix it.
+
+- [ ] **Step 4: Update the guide**
+
+In `docs/guides/resilience-patterns.md`, extend the two tagged-mode caveat passages: keep the existing #86 explanation and add one sentence — "As of 0.5.4, `.tagged` is deprecated and will be removed in 0.6; use `PartitionedBulkheadMiddleware` with `allowBorrowing: false` for real per-tenant capacity." (Match the surrounding prose style; do not rewrite the sections.)
+
+- [ ] **Step 5: Run bulkhead tests, commit**
+
+```bash
+swift test --filter "BulkheadMiddlewareTests"
+git add Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift docs/guides/resilience-patterns.md
+git commit -m "deprecate(resilience): BulkheadMiddleware.IsolationMode.tagged — shared semaphore, not isolation (#86)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+Expected: tests PASS (no shipped test constructs `.tagged` — verified during planning).
+
+---
+
+### Task 8: PR 3 (part 3) — truthful auth-error docs, CHANGELOG, open PR
+
+**Files:**
+- Modify: `Sources/PipelineKitSecurity/Middleware/Authentication/AuthenticationMiddleware.swift` (doc comments only: lines 25, 31, 57, 72, 86)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Rewrite the phantom `AuthenticationError` references**
+
+`AuthenticationError` exists nowhere in the package; the middleware rethrows whatever the caller's `authenticate` closure throws. Update the example (:20–35) to define its own error:
+
+```swift
+/// ```swift
+/// enum AuthError: Error {
+///     case missingCredentials
+///     case userInactive
+/// }
+///
+/// let authMiddleware = AuthenticationMiddleware { userId in
+///     // Validate user credentials
+///     guard let userId = userId else {
+///         throw AuthError.missingCredentials
+///     }
+///
+///     // Verify user exists and is active
+///     let user = try await userService.verify(userId)
+///     guard user.isActive else {
+///         throw AuthError.userInactive
+///     }
+///
+///     return user.id
+/// }
+/// ```
+```
+
+Then: `:57` `- SeeAlso:` — drop the `AuthenticationError` reference (keep `Middleware`); `:72` — "Should throw your own error type for authentication failures; the middleware rethrows it unchanged."; `:86` — "- Throws: Whatever your `authenticate` closure throws when authentication fails, or any error from the downstream chain."
+
+- [ ] **Step 2: Build docs-affected target**
+
+```bash
+swift build --target PipelineKitSecurity
+```
+
+Expected: success, no new warnings.
+
+- [ ] **Step 3: CHANGELOG entries**
+
+Under `## [Unreleased]` add:
+
+```markdown
+### Deprecated
+- `PartitionedBulkheadMiddleware.Configuration.maxBorrowPercentage` (and its
+  init parameter): renamed to `reservedCapacityPercentage` — the value has
+  always been the lender's *reserved* share, not a borrowing cap. Semantics
+  unchanged; the old spellings forward and will be removed in 0.6.
+- `BulkheadMiddleware.IsolationMode.tagged`: never provided per-tag isolation
+  (all tags share one semaphore; the tag is context metadata only, [#86]).
+  Use `PartitionedBulkheadMiddleware` with `allowBorrowing: false`. Removal
+  in 0.6.
+
+### Fixed
+- `AuthenticationMiddleware` documentation no longer references
+  `AuthenticationError`, a type that does not exist; the middleware rethrows
+  whatever the `authenticate` closure throws, and the docs now say so.
+```
+
+(Ensure a `[#86]:` reference link exists at the bottom of CHANGELOG.md following the existing pattern.)
+
+- [ ] **Step 4: Full filtered suite, push, open PR (leave open)**
+
+```bash
+swift test --parallel --skip PipelineKitPerformanceTests
+git add CHANGELOG.md Sources/PipelineKitSecurity/Middleware/Authentication/AuthenticationMiddleware.swift
+git commit -m "docs(security): AuthenticationMiddleware rethrows the closure's error — remove phantom AuthenticationError; CHANGELOG for 0.5.4 polish
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin chore/api-docs-polish-0.5.4
+gh pr create --title "chore: 0.5.4 API/docs polish — reservedCapacityPercentage rename, deprecate .tagged, truthful auth docs" --body "$(cat <<'EOF'
+Audit findings F-24, F-22 (#86), F-27c. Closes #86.
+
+- `maxBorrowPercentage` → `reservedCapacityPercentage` with deprecated forwarding alias + init overload (semantics unchanged; the old name said the opposite of what the value does).
+- `IsolationMode.tagged` deprecated: all tags share one semaphore; real per-tenant capacity is `PartitionedBulkheadMiddleware(allowBorrowing: false)`. Removal in 0.6. One intentional internal deprecation warning at the dispatch match site.
+- `AuthenticationMiddleware` docs stop referencing the nonexistent `AuthenticationError`.
+
+Maintainer gate: full unfiltered suite in Xcode before merge.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Task 9: Housekeeping — 0.6 tracking + release checklist
+
+**Files:** none (GitHub + checklist only)
+
+- [ ] **Step 1: File the 0.6 error/cancellation contract issue**
+
+```bash
+gh issue create \
+  --title "0.6: unify the error & cancellation contract (audit F-26, F-27a/b)" \
+  --body "$(cat <<'EOF'
+Batched behavior changes for 0.6 under one Breaking/Changed heading (from the 2026-08 pre-integration audit):
+
+- **F-26a** StandardPipeline checks cancellation only pre-start (`insertCancellationChecks: false` at StandardPipeline.swift:431); AnyStandardPipeline/DynamicPipeline check per middleware. Flip for consistency — in-flight commands will throw mid-chain instead of running to completion.
+- **F-26b** Cancellation error identity is inconsistent: SimpleSemaphore (:88,:126) and BackPressureSemaphore (:187) throw `Swift.CancellationError`; AsyncSemaphore throws `PipelineError.cancelled`. Unify on `PipelineError.cancelled`; ~10+ test assertions to update.
+- **F-26c** `CancellationReason` is dead API outside TimeoutMiddleware — wire `context.markAsCancelled` into cancellation paths or deprecate.
+- **F-27a** `EncryptionMiddleware` throws raw `EncryptionError` at 4 sites while lower layers correctly use `PipelineError.encryption(reason:)` — wrap.
+- **F-27b** `PipelineError.circuitBreakerOpen` has zero construction sites (the breaker throws `.middlewareError`) — construct it in the breaker or remove the case. Touches the same catch path as the probe-lifecycle fix.
+
+Rationale for batching: error-identity churn across multiple releases burns integrators repeatedly; one labeled release does it once.
+EOF
+)"
+```
+
+- [ ] **Step 2: Post the F-23 sharpening on #87**
+
+```bash
+gh issue comment 87 --body "$(cat <<'EOF'
+Audit sharpening (2026-08, finding F-23): the blast radius is worse than "bad telemetry." With `blockUnhealthyServices: true` and no standalone `HealthCheck` configured for the service, `.unhealthy` is a **terminal** state: blocked requests are rejected before the do/catch so nothing is recorded, window pruning happens only inside `recordSuccess`/`recordFailure` (:707/:722), and state recomputes only on record events (:659-675) — permanent traffic shedding with no recovery path. With defaults (`failureThreshold: 5`, `minRequests: 10`), five consecutive validation rejections get there. A fix needs both an error-classification hook (cf. the breaker's `shouldTriggerCircuit`) and a recovery path that doesn't depend on record events. Also: `HealthCheckError.checkFailed` has zero construction sites.
+EOF
+)"
+```
+
+- [ ] **Step 3: Post-merge release checklist (maintainer-gated — record it, don't execute merges)**
+
+For the maintainer, in order: run the full unfiltered suite in Xcode per PR → merge PR 1, PR 2, PR 3 (CHANGELOG `[Unreleased]` conflicts between them are line-append trivial) → cut the `## [0.5.4]` CHANGELOG section (move the Unreleased entries, date it, add the version link) → update install-snippet pins from `0.5.2`/`0.5.3` to `0.5.4` if desired (S1 doc smell; optional, `from:` resolves forward) → tag `v0.5.4` and push the tag (release.yml handles the rest) → delete branch `audit/verification-tests` (both files have landed via PRs 1–2).
+
+---
+
+## Self-review notes
+
+- Spec coverage: D1→Tasks 1–4, D2→Task 5, D3→Task 6, D4→Task 7, D5→Task 8, issue/tracking→Tasks 1 & 9. Non-goals are in the 0.6 issue, not tasks. ✓
+- The `.closed`/`.open` record-branch bodies are intentionally not reproduced in Task 3 Step 3 — they are byte-for-byte the existing code; only the `.halfOpen` guard lines are added. The full existing bodies were verified during planning (audit F-17/18 evidence).
+- Type consistency: `Admission` is used only inside `CircuitBreakerMiddleware`; test fixtures are file-private per file (`ProbeCommand` in the audit file, `AccountingCommand` in the new file) to avoid cross-file collisions. ✓
+- Known flex points called out inline: `PartitionConfig` fixture init (Task 6 Step 2), the example's exact declaration line (Task 5 Step 5).

--- a/docs/superpowers/specs/2026-08-13-release-0.5.4-audit-fixes-design.md
+++ b/docs/superpowers/specs/2026-08-13-release-0.5.4-audit-fixes-design.md
@@ -1,0 +1,120 @@
+# Release 0.5.4 — Audit Fixes: Design
+
+**Date:** 2026-08-13
+**Source:** Pre-integration audit of v0.5.3 (findings F-17/18, F-04/12, F-22, F-24, F-27c; audit branch `audit/verification-tests` @ 96853c8)
+**Release type:** Patch (0.5.x) — per VERSIONING.md: bug fixes, docs, and additive/deprecating API only; no source breaks, no documented-behavior breaks.
+
+## Goals
+
+Ship a 0.5.4 tag whose contents are exclusively patch-safe audit remediations:
+
+1. **F-17 + F-18 — CircuitBreakerMiddleware probe lifecycle (the one runtime bug).**
+   A half-open probe that exits via a non-triggering error (e.g. `CancellationError`,
+   hardcoded non-triggering) records neither success nor failure; `probeInProgress`
+   is never cleared and `allowRequest()` has no half-open escape → the breaker
+   rejects all traffic forever (F-17). Separately, *any* request completing during
+   half-open drives probe accounting — a stale closed-era success clears the probe
+   flag and counts toward `halfOpenSuccessThreshold` (F-18).
+2. **F-04/12 — NextGuard warning noise.** Nine shipped middlewares short-circuit
+   (throw or return) without `NextGuardWarningSuppressing`, producing false
+   debug "deallocated without calling next()" warnings on every normal rejection.
+3. **F-24 — `maxBorrowPercentage` says the opposite of what it does.** The value is
+   the lender's *reserved* share (0.2 ⇒ up to ~80% lendable). Docs were corrected
+   in 0.5.2; the API name still lies.
+4. **F-22 / #86 — `.tagged` bulkhead isolation is not isolation.** All tags share
+   one semaphore. Resolution: deprecate, point at the real mechanism.
+5. **F-27c — phantom `AuthenticationError`.** `AuthenticationMiddleware` doc
+   comments reference a type that exists nowhere; the middleware actually rethrows
+   whatever the caller's `authenticate` closure throws.
+
+## Key design decisions
+
+### D1. Probe lifecycle: admission roles + guaranteed resolution (F-17/18 in one mechanism)
+
+`State.allowRequest() -> Bool` becomes `State.admitRequest() -> Admission`
+(`.rejected` / `.normal` / `.probe`), so `execute` knows whether *this* request is
+the probe. New invariant, enforced in the state machine:
+
+> **Half-open transitions are driven solely by the probe's outcome.**
+
+- `recordSuccess(asProbe:)` / `recordFailure(asProbe:)`: in `.halfOpen`, non-probe
+  outcomes are ignored (they belong to the closed era). This fixes F-18. Trade-off
+  accepted: a stale *triggering* failure no longer re-opens the circuit during
+  half-open; the probe's own outcome decides. Closed/open branches unchanged.
+- New `abandonProbe()`: clears `probeInProgress` iff still `.halfOpen`.
+- `execute` guarantees resolution with a `defer`: a probe that exits without
+  recording an outcome (non-triggering error, cancellation) abandons the probe so
+  the next request becomes the new probe. An `outcomeRecorded` flag prevents the
+  defer from clearing a *subsequent* probe's slot in the tiny window after this
+  probe resolves. This fixes F-17.
+- No config changes, no public API changes (`State` is private). No probe
+  deadline: if `next` hangs forever that is a timeout-middleware concern, and the
+  defer covers every throwing/cancelling exit.
+
+### D2. Warning suppression is a declaration of intent (F-04/12)
+
+Add `NextGuardWarningSuppressing` to the nine short-circuiting middlewares on
+their declaration lines (house style, matching `AuthorizationMiddleware`):
+BackPressureMiddleware (actor), CircuitBreakerMiddleware, RateLimitingMiddleware,
+EnhancedRateLimitingMiddleware, BulkheadMiddleware, PartitionedBulkheadMiddleware,
+HealthCheckMiddleware, ValidationMiddleware, SecurityPolicyMiddleware. Precedent:
+the four caching middlewares and both auth middlewares already conform for exactly
+this reason. Pin with metatype conformance assertions (no instantiation needed).
+Also conform `AdvancedExample`'s `OrderValidationMiddleware` — the shipped example
+currently prints the false warning on its own demo rejection path.
+
+### D3. Truthful name with a deprecated alias (F-24)
+
+`Configuration.maxBorrowPercentage` → stored `reservedCapacityPercentage`
+(same semantics, same default 0.2). Old name survives as a deprecated computed
+alias; old init survives as a deprecated overload whose `maxBorrowPercentage:`
+label has **no default value** (so unlabeled calls unambiguously resolve to the
+new primary init). Flipping semantics to match the old name was rejected: it
+would silently re-tune every existing config.
+
+### D4. Deprecate `.tagged`, close #86 as by-design (F-22)
+
+`IsolationMode.tagged` gets `@available(*, deprecated, ...)` pointing at
+`PartitionedBulkheadMiddleware` with `allowBorrowing: false`. Behavior unchanged
+until removal in 0.6. One expected internal deprecation warning at the dispatch
+match site in `execute` — deliberate (deprecation is viral to pattern matches);
+annotated with a comment. Per-tag semaphores were rejected: unbounded tag
+cardinality needs a cap/eviction design, and PartitionedBulkhead already delivers
+bounded per-tenant capacity.
+
+### D5. Docs tell the truth about auth errors (F-27c)
+
+Rewrite the five `AuthenticationError` references in `AuthenticationMiddleware`
+doc comments: the example defines its own error enum; the Throws docs say the
+middleware rethrows the `authenticate` closure's error. (Unifying error identity
+across the package is 0.6 scope — see Non-goals.)
+
+## Delivery shape
+
+Three sequential PRs, each branched from `main`, each with its own CHANGELOG
+`[Unreleased]` entry (trivial merge conflicts accepted):
+
+- **PR 1** `fix/circuit-breaker-probe-lifecycle` — D1 + evidence tests (audit
+  wedge tests cherry-picked, wedge pin inverted into a recovery assertion, new
+  stale-attribution test). References the new probe-lifecycle issue.
+- **PR 2** `chore/nextguard-warning-suppression` — D2 + the audit's
+  retry-through-guarded-chain evidence tests (NextGuard-domain).
+- **PR 3** `chore/api-docs-polish-0.5.4` — D3 + D4 + D5. Closes #86.
+
+Issues: file one new issue for the probe lifecycle defect (referenced by PR 1);
+file one 0.6 umbrella issue for the error/cancellation contract batch
+(F-26 + F-27a/b); post the F-23 terminal-state sharpening as a comment on #87.
+
+Human gates (house rules): full unfiltered suite in Xcode before each merge;
+maintainer merges PRs and cuts the 0.5.4 CHANGELOG section + tag.
+
+## Non-goals (deferred to 0.6, tracked before the tag)
+
+- F-26 cancellation semantics (mid-chain checks in StandardPipeline, unified
+  cancellation error identity, `CancellationReason` wiring) — behavior changes,
+  batched under one Breaking/Changed heading.
+- F-27a/b error identity (`EncryptionError` wrapping, `circuitBreakerOpen`
+  construct-or-remove — the latter touches the same catch path as D1 and lands
+  with the 0.6 batch).
+- F-23 / #87 health-check redesign (error classification + recovery path).
+- Removal of `maxBorrowPercentage` alias and `.tagged` (0.6, under Breaking).


### PR DESCRIPTION
Fixes #92 (audit findings F-17/F-18).

- `admitRequest() -> Admission` (private): execute knows whether this request is the half-open probe.
- `defer`-guaranteed probe resolution: a probe exiting via a non-triggering error abandons the slot instead of wedging the breaker permanently.
- Half-open transitions driven solely by the probe's outcome; stale closed-era requests are ignored.
- Evidence: audit wedge test inverted into a recovery assertion; new deterministic stale-attribution test with async gates.

No public API or configuration changes; `State` is private.

Maintainer gate: full unfiltered suite in Xcode before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)