### PR TITLE
fix(middleware): suppress false NextGuard warnings on short-circuit paths; land retry evidence tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Rejection paths of `BackPressureMiddleware`, `CircuitBreakerMiddleware`,
+  `RateLimitingMiddleware`, `EnhancedRateLimitingMiddleware`,
+  `BulkheadMiddleware`, `PartitionedBulkheadMiddleware`,
+  `HealthCheckMiddleware`, `ValidationMiddleware`, and
+  `SecurityPolicyMiddleware` no longer emit false debug
+  "NextGuard deallocated without calling next()" warnings: all nine now
+  conform to `NextGuardWarningSuppressing`, matching the caching and auth
+  middlewares.
+
 ## [0.5.3] - 2026-08-08
 
 ### Fixed

--- a/Examples/Sources/AdvancedExample/main.swift
+++ b/Examples/Sources/AdvancedExample/main.swift
@@ -41,7 +41,7 @@ struct SubmitOrderHandler: CommandHandler {
 
 // MARK: - Custom middleware
 
-struct OrderValidationMiddleware: Middleware {
+struct OrderValidationMiddleware: Middleware, NextGuardWarningSuppressing {
     let priority = ExecutionPriority.validation
 
     func execute<T: Command>(

--- a/Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift
@@ -57,7 +57,7 @@ import _ResilienceFoundation
 /// 3. Bulkhead (isolate resources)
 /// 4. Timeout (bound execution time)
 /// 5. Retry (handle transient failures)
-public struct BulkheadMiddleware: Middleware {
+public struct BulkheadMiddleware: Middleware, NextGuardWarningSuppressing {
     public let priority: ExecutionPriority = .resilience
 
     // MARK: - Configuration

--- a/Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift
@@ -30,7 +30,7 @@ import os
 ///   - Network operations: 5-10 failures before opening
 ///   - Database operations: 2-5 failures before opening
 ///   - Critical services: 1-3 failures with longer recovery timeout
-public struct CircuitBreakerMiddleware: Middleware {
+public struct CircuitBreakerMiddleware: Middleware, NextGuardWarningSuppressing {
     public let priority: ExecutionPriority = .resilience
     
     // MARK: - Internal State

--- a/Sources/PipelineKitResilienceCircuitBreaker/HealthCheckMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/HealthCheckMiddleware.swift
@@ -30,7 +30,7 @@ import PipelineKitCore
 /// )
 /// pipeline.use(middleware)
 /// ```
-public struct HealthCheckMiddleware: Middleware {
+public struct HealthCheckMiddleware: Middleware, NextGuardWarningSuppressing {
     /// Runs in the `.resilience` priority band, alongside circuit breakers, retries,
     /// and timeouts.
     public let priority: ExecutionPriority = .resilience

--- a/Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift
@@ -31,7 +31,7 @@ import PipelineKitCore
 ///     }
 /// )
 /// ```
-public struct PartitionedBulkheadMiddleware: Middleware {
+public struct PartitionedBulkheadMiddleware: Middleware, NextGuardWarningSuppressing {
     /// Runs in the `.resilience` priority band, alongside circuit breakers, retries,
     /// and timeouts.
     public let priority: ExecutionPriority = .resilience

--- a/Sources/PipelineKitResilienceCore/BackPressureMiddleware.swift
+++ b/Sources/PipelineKitResilienceCore/BackPressureMiddleware.swift
@@ -4,7 +4,7 @@ import Atomics
 import _ResilienceFoundation
 
 /// Middleware that enforces back-pressure limits on command execution
-public actor BackPressureMiddleware: Middleware {
+public actor BackPressureMiddleware: Middleware, NextGuardWarningSuppressing {
     public let priority: ExecutionPriority = .preProcessing
     
     private let semaphore: BackPressureSemaphore

--- a/Sources/PipelineKitResilienceRateLimiting/EnhancedRateLimitingMiddleware.swift
+++ b/Sources/PipelineKitResilienceRateLimiting/EnhancedRateLimitingMiddleware.swift
@@ -25,7 +25,7 @@ import PipelineKit
 ///     }
 /// )
 /// ```
-public struct EnhancedRateLimitingMiddleware: Middleware {
+public struct EnhancedRateLimitingMiddleware: Middleware, NextGuardWarningSuppressing {
     public let priority: ExecutionPriority = .authentication
     private let limiter: RateLimiter
     private let identifierExtractor: @Sendable (any Command, CommandContext) async -> String

--- a/Sources/PipelineKitResilienceRateLimiting/RateLimitingMiddleware.swift
+++ b/Sources/PipelineKitResilienceRateLimiting/RateLimitingMiddleware.swift
@@ -11,7 +11,7 @@ import PipelineKit
 /// )
 /// let middleware = RateLimitingMiddleware(limiter: limiter)
 /// ```
-public struct RateLimitingMiddleware: Middleware {
+public struct RateLimitingMiddleware: Middleware, NextGuardWarningSuppressing {
     public let priority: ExecutionPriority = .authentication
     private let limiter: RateLimiter
     private let identifierExtractor: @Sendable (any Command, CommandContext) async -> String

--- a/Sources/PipelineKitSecurity/Middleware/Validation/ValidationMiddleware.swift
+++ b/Sources/PipelineKitSecurity/Middleware/Validation/ValidationMiddleware.swift
@@ -21,7 +21,7 @@ import PipelineKit
 ///     priority: ExecutionPriority.validation.rawValue
 /// )
 /// ```
-public struct ValidationMiddleware: Middleware {
+public struct ValidationMiddleware: Middleware, NextGuardWarningSuppressing {
     public let priority: ExecutionPriority = .validation
     
     public init() {}

--- a/Sources/PipelineKitSecurity/Policies/SecurityPolicy.swift
+++ b/Sources/PipelineKitSecurity/Policies/SecurityPolicy.swift
@@ -69,7 +69,7 @@ public struct SecurityPolicy: Sendable {
 /// 
 /// This middleware applies configured security policies to all commands,
 /// providing an additional layer of protection beyond basic validation.
-public struct SecurityPolicyMiddleware: Middleware {
+public struct SecurityPolicyMiddleware: Middleware, NextGuardWarningSuppressing {
     public let priority: ExecutionPriority = .custom
     private let policy: SecurityPolicy
     

--- a/Tests/PipelineKitResilienceTests/AuditRetryThroughGuardedChainTests.swift
+++ b/Tests/PipelineKitResilienceTests/AuditRetryThroughGuardedChainTests.swift
@@ -1,0 +1,159 @@
+//
+//  AuditRetryThroughGuardedChainTests.swift
+//  PipelineKit
+//
+//  Audit evidence tests (2026-08): pin the scenario an external review flagged as a
+//  blocker — a retry's SECOND attempt traversing a guarded (non-Unsafe) middleware.
+//  Safety rests on two independent properties:
+//  1. RetryMiddleware/ResilientMiddleware conform to `UnsafeMiddleware`, so their own
+//     `next` is unguarded and may be called once per attempt.
+//  2. `MiddlewareChainBuilder.build` mints fresh `NextGuard`s inside the chain closure
+//     on every invocation, so downstream guarded middleware gets a new guard per attempt.
+//  Prior coverage exercised retry middlewares only in isolation (bare closures) or
+//  cached-chain reuse across separate executions — never a real second attempt through
+//  a guarded middleware. These tests close that gap.
+//
+
+import XCTest
+@testable import PipelineKitCore
+import PipelineKitResilience
+import PipelineKit
+
+// MARK: - Fixtures
+
+private enum AuditTestError: Error {
+    case transient
+}
+
+/// Actor-backed counter so fixtures stay Sendable under strict concurrency.
+private actor AttemptCounter {
+    private var count = 0
+
+    func increment() -> Int {
+        count += 1
+        return count
+    }
+
+    var value: Int { count }
+}
+
+private struct PingCommand: Command {
+    typealias Result = String
+}
+
+/// Fails on the first attempt, succeeds on every subsequent one.
+private struct FailOnceHandler: CommandHandler {
+    typealias CommandType = PingCommand
+    let attempts: AttemptCounter
+
+    func handle(_ command: PingCommand, context: CommandContext) async throws -> String {
+        let attempt = await attempts.increment()
+        if attempt == 1 {
+            throw AuditTestError.transient
+        }
+        return "ok after \(attempt)"
+    }
+}
+
+/// A plain, guarded middleware (NOT `UnsafeMiddleware`): every traversal goes through a
+/// freshly minted `NextGuard`. Counts traversals so the test can prove the second retry
+/// attempt actually passed through it.
+private struct GuardedCountingMiddleware: Middleware {
+    let priority: ExecutionPriority = .custom
+    let traversals: AttemptCounter
+
+    func execute<T: Command>(
+        _ command: T,
+        context: CommandContext,
+        next: @Sendable (T, CommandContext) async throws -> T.Result
+    ) async throws -> T.Result {
+        _ = await traversals.increment()
+        return try await next(command, context)
+    }
+}
+
+// MARK: - Tests
+
+final class AuditRetryThroughGuardedChainTests: XCTestCase {
+    /// RetryMiddleware's second attempt must traverse a guarded downstream middleware
+    /// without throwing `PipelineError.nextAlreadyCalled`.
+    func testRetryMiddlewareSecondAttemptTraversesGuardedMiddleware() async throws {
+        let attempts = AttemptCounter()
+        let traversals = AttemptCounter()
+        let pipeline = StandardPipeline(handler: FailOnceHandler(attempts: attempts))
+
+        let retry = RetryMiddleware(
+            configuration: RetryMiddleware.Configuration(
+                maxAttempts: 3,
+                errorEvaluator: { error in error is AuditTestError }
+            )
+        )
+        try await pipeline.addMiddleware(retry)
+        try await pipeline.addMiddleware(GuardedCountingMiddleware(traversals: traversals))
+
+        let result = try await pipeline.execute(PingCommand(), context: CommandContext())
+
+        XCTAssertEqual(result, "ok after 2")
+        let handlerAttempts = await attempts.value
+        let guardedTraversals = await traversals.value
+        XCTAssertEqual(handlerAttempts, 2, "handler should have been attempted twice")
+        XCTAssertEqual(
+            guardedTraversals, 2,
+            "the guarded middleware must be traversed once per attempt with a fresh NextGuard"
+        )
+    }
+
+    /// Same property for ResilientMiddleware's internal retry loop.
+    func testResilientMiddlewareSecondAttemptTraversesGuardedMiddleware() async throws {
+        let attempts = AttemptCounter()
+        let traversals = AttemptCounter()
+        let pipeline = StandardPipeline(handler: FailOnceHandler(attempts: attempts))
+
+        let resilient = ResilientMiddleware(
+            name: "audit",
+            retryPolicy: RetryPolicy(
+                maxAttempts: 2,
+                delayStrategy: .immediate,
+                shouldRetry: { _ in true }
+            )
+        )
+        try await pipeline.addMiddleware(resilient)
+        try await pipeline.addMiddleware(GuardedCountingMiddleware(traversals: traversals))
+
+        let result = try await pipeline.execute(PingCommand(), context: CommandContext())
+
+        XCTAssertEqual(result, "ok after 2")
+        let guardedTraversals = await traversals.value
+        XCTAssertEqual(
+            guardedTraversals, 2,
+            "the guarded middleware must be traversed once per attempt with a fresh NextGuard"
+        )
+    }
+
+    /// DynamicPipeline's own `send(_:retryPolicy:)` loop re-invokes the cached chain; every
+    /// attempt must re-mint guards for ALL middleware (this loop sits outside the chain, so
+    /// even non-Unsafe middleware is legitimately re-executed).
+    func testDynamicPipelineRetryPolicyReExecutesGuardedChain() async throws {
+        let attempts = AttemptCounter()
+        let traversals = AttemptCounter()
+        let pipeline = DynamicPipeline()
+        await pipeline.register(PingCommand.self, handler: FailOnceHandler(attempts: attempts))
+        try await pipeline.addMiddleware(GuardedCountingMiddleware(traversals: traversals))
+
+        let result = try await pipeline.send(
+            PingCommand(),
+            retryPolicy: RetryPolicy(
+                maxAttempts: 3,
+                delayStrategy: .immediate,
+                shouldRetry: { _ in true }
+            )
+        )
+
+        XCTAssertEqual(result, "ok after 2")
+        let guardedTraversals = await traversals.value
+        XCTAssertEqual(
+            guardedTraversals, 2,
+            "each retry attempt must re-run the guarded middleware with a fresh NextGuard"
+        )
+    }
+}

--- a/Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift
+++ b/Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift
@@ -1,0 +1,26 @@
+//
+//  NextGuardSuppressionConformanceTests.swift
+//  PipelineKit
+//
+//  Middlewares that intentionally short-circuit (throw a rejection or return
+//  without calling next) must conform to NextGuardWarningSuppressing so their
+//  normal rejection paths don't emit false debug "deallocated without calling
+//  next()" warnings. Metatype assertions pin the contract without needing to
+//  construct configurations.
+//
+
+import XCTest
+import PipelineKitCore
+import PipelineKitResilience
+
+final class NextGuardSuppressionConformanceTests: XCTestCase {
+    func testShortCircuitingResilienceMiddlewaresSuppressNextGuardWarnings() {
+        XCTAssertTrue(BackPressureMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(CircuitBreakerMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(RateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(EnhancedRateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(BulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(PartitionedBulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(HealthCheckMiddleware.self is any NextGuardWarningSuppressing.Type)
+    }
+}

--- a/Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift
+++ b/Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+import PipelineKitCore
+import PipelineKitSecurity
+
+final class NextGuardSuppressionConformanceTests: XCTestCase {
+    func testShortCircuitingSecurityMiddlewaresSuppressNextGuardWarnings() {
+        XCTAssertTrue(ValidationMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(SecurityPolicyMiddleware.self is any NextGuardWarningSuppressing.Type)
+    }
+}


### PR DESCRIPTION
Audit findings F-04/F-12 (+ retry evidence tests from F-10/F-11).

- Nine short-circuiting middlewares conform to `NextGuardWarningSuppressing` (debug-only diagnostics; zero runtime change).
- `AdvancedExample` no longer prints the false warning on its demo rejection path.
- New conformance-assertion tests pin the contract; audit retry tests pin fresh-guard-per-attempt through StandardPipeline, ResilientMiddleware, and DynamicPipeline's retryPolicy loop.

Maintainer gate: full unfiltered suite in Xcode before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)