### PR TITLE
chore: 0.5.4 API/docs polish — reservedCapacityPercentage rename, deprecate .tagged, truthful auth docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- `PartitionedBulkheadMiddleware.Configuration.maxBorrowPercentage` (and its
+  init parameter): renamed to `reservedCapacityPercentage` — the value has
+  always been the lender's *reserved* share, not a borrowing cap. Semantics
+  unchanged; the old spellings forward and will be removed in 0.6.
+- `BulkheadMiddleware.IsolationMode.tagged`: never provided per-tag isolation
+  (all tags share one semaphore; the tag is context metadata only, [#86]).
+  Use `PartitionedBulkheadMiddleware` with `allowBorrowing: false`. Removal
+  in 0.6.
+
+### Fixed
+- `AuthenticationMiddleware` documentation no longer references
+  `AuthenticationError`, a type that does not exist; the middleware rethrows
+  whatever the `authenticate` closure throws, and the docs now say so.
+
 ## [0.5.3] - 2026-08-08
 
 ### Fixed
@@ -327,4 +342,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3.1]: https://github.com/gifton/PipelineKit/releases/tag/v0.3.1
 [0.2.0]: https://github.com/gifton/PipelineKit/releases/tag/v0.2.0
 [#85]: https://github.com/gifton/PipelineKit/issues/85
+[#86]: https://github.com/gifton/PipelineKit/issues/86
 [#88]: https://github.com/gifton/PipelineKit/issues/88

--- a/Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift
@@ -191,8 +191,10 @@ public struct BulkheadMiddleware: Middleware {
                 startTime: startTime
             )
 
-        // Deprecation warning on this match is expected and accepted: the case
-        // stays functional until its removal in 0.6.
+        // This case is deprecated (#86) but the match must stay exhaustive so
+        // .tagged keeps working until its removal in 0.6. Swift's deprecation
+        // diagnostic fires at construction sites, not on this pattern match, so
+        // no warning appears here — that's expected.
         case let .tagged(keyExtractor):
             let tag = keyExtractor(command)
             return try await executeTaggedIsolation(

--- a/Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift
@@ -127,6 +127,7 @@ public struct BulkheadMiddleware: Middleware {
         case taskGroup(priority: TaskPriority?)
 
         /// Use tagged isolation for different command types
+        @available(*, deprecated, message: "Tagged mode never provided per-tag isolation — every tag contends on the same shared semaphore, and the tag is recorded only as context metadata (#86). For real per-tenant capacity use PartitionedBulkheadMiddleware with allowBorrowing: false. This mode will be removed in 0.6.")
         case tagged(keyExtractor: @Sendable (any Command) -> String)
     }
 
@@ -190,6 +191,8 @@ public struct BulkheadMiddleware: Middleware {
                 startTime: startTime
             )
 
+        // Deprecation warning on this match is expected and accepted: the case
+        // stays functional until its removal in 0.6.
         case let .tagged(keyExtractor):
             let tag = keyExtractor(command)
             return try await executeTaggedIsolation(

--- a/Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift
@@ -104,18 +104,23 @@ public struct PartitionedBulkheadMiddleware: Middleware {
 
         /// Whether `execute(_:context:next:)` may borrow spare capacity from other
         /// partitions when a command's own partition is full (see
-        /// `maxBorrowPercentage`).
+        /// `reservedCapacityPercentage`).
         public let allowBorrowing: Bool
 
         /// The fraction (`0.0`–`1.0`) of a lending partition's capacity that is
         /// reserved for that partition's own commands and never lent out.
         ///
-        /// Despite the property name, this is a *reservation*, not a borrowing cap:
-        /// a candidate partition may lend from `capacity - activeCount -
-        /// (capacity * maxBorrowPercentage)` of its capacity, so with the default
-        /// `0.2`, up to ~80% of an otherwise-idle partition's capacity can be lent
-        /// to other partitions, not 20%.
-        public let maxBorrowPercentage: Double
+        /// With the default `0.2`, up to ~80% of an otherwise-idle partition's
+        /// capacity can be lent to other partitions.
+        public let reservedCapacityPercentage: Double
+
+        /// Deprecated alias for ``reservedCapacityPercentage``.
+        ///
+        /// Despite the historical name, this value has always been the lender's
+        /// *reserved* (non-lendable) share, not a borrowing cap — renamed to say
+        /// what it does. The semantics are unchanged.
+        @available(*, deprecated, renamed: "reservedCapacityPercentage")
+        public var maxBorrowPercentage: Double { reservedCapacityPercentage }
 
         /// Whether `execute(_:context:next:)` records per-partition context
         /// metadata and emits `middleware.partitioned_bulkhead_execution` /
@@ -132,9 +137,9 @@ public struct PartitionedBulkheadMiddleware: Middleware {
         ///     in `partitions` for commands to succeed when they fall back to it.
         ///   - allowBorrowing: Whether to allow borrowing capacity from other
         ///     partitions. Defaults to `true`.
-        ///   - maxBorrowPercentage: The fraction of a lending partition's capacity
-        ///     reserved for its own use (see the property documentation for the
-        ///     resulting lendable share). Defaults to `0.2`.
+        ///   - reservedCapacityPercentage: The fraction of a lending partition's
+        ///     capacity reserved for its own use (see the property documentation
+        ///     for the resulting lendable share). Defaults to `0.2`.
         ///   - emitMetrics: Whether to record context metadata and emit middleware
         ///     events. Defaults to `true`.
         public init(
@@ -142,15 +147,35 @@ public struct PartitionedBulkheadMiddleware: Middleware {
             partitionExtractor: @escaping @Sendable (any Command, CommandContext) async -> String,
             defaultPartition: String = "default",
             allowBorrowing: Bool = true,
-            maxBorrowPercentage: Double = 0.2,
+            reservedCapacityPercentage: Double = 0.2,
             emitMetrics: Bool = true
         ) {
             self.partitions = partitions
             self.partitionExtractor = partitionExtractor
             self.defaultPartition = defaultPartition
             self.allowBorrowing = allowBorrowing
-            self.maxBorrowPercentage = maxBorrowPercentage
+            self.reservedCapacityPercentage = reservedCapacityPercentage
             self.emitMetrics = emitMetrics
+        }
+
+        /// Deprecated: use `init(partitions:partitionExtractor:defaultPartition:allowBorrowing:reservedCapacityPercentage:emitMetrics:)`.
+        @available(*, deprecated, message: "maxBorrowPercentage has always been the reserved (non-lendable) share — use reservedCapacityPercentage, which has identical semantics.")
+        public init(
+            partitions: [String: PartitionConfig],
+            partitionExtractor: @escaping @Sendable (any Command, CommandContext) async -> String,
+            defaultPartition: String = "default",
+            allowBorrowing: Bool = true,
+            maxBorrowPercentage: Double,
+            emitMetrics: Bool = true
+        ) {
+            self.init(
+                partitions: partitions,
+                partitionExtractor: partitionExtractor,
+                defaultPartition: defaultPartition,
+                allowBorrowing: allowBorrowing,
+                reservedCapacityPercentage: maxBorrowPercentage,
+                emitMetrics: emitMetrics
+            )
         }
     }
 
@@ -179,7 +204,7 @@ public struct PartitionedBulkheadMiddleware: Middleware {
 
     /// Convenience initializer that builds a `Configuration` from just the
     /// partitions and extractor, using default values (borrowing enabled,
-    /// `maxBorrowPercentage` `0.2`, `defaultPartition` `"default"`, metrics
+    /// `reservedCapacityPercentage` `0.2`, `defaultPartition` `"default"`, metrics
     /// enabled) for everything else.
     ///
     /// - Parameters:
@@ -215,7 +240,7 @@ public struct PartitionedBulkheadMiddleware: Middleware {
     ///    capacity`) — the command runs right away.
     /// 2. **Borrowed** (only if `Configuration.allowBorrowing` is `true`): another
     ///    partition has capacity available to lend (see
-    ///    `Configuration.maxBorrowPercentage`) — the command runs using that
+    ///    `Configuration.reservedCapacityPercentage`) — the command runs using that
     ///    partition's slot, and the slot is released back to the lending
     ///    partition afterward.
     /// 3. **Queued** (only if the partition's `PartitionConfig.queueSize` is
@@ -491,8 +516,8 @@ private actor PartitionManager {
         // Find partitions with available capacity
         for (key, partition) in partitions where key != requestingPartition {
             let stats = await partition.getStats()
-            let borrowableCapacity = Int(Double(stats.capacity) * configuration.maxBorrowPercentage)
-            let availableForBorrowing = stats.capacity - stats.activeCount - borrowableCapacity
+            let reservedCapacity = Int(Double(stats.capacity) * configuration.reservedCapacityPercentage)
+            let availableForBorrowing = stats.capacity - stats.activeCount - reservedCapacity
 
             if availableForBorrowing > 0 {
                 let acquired = await partition.tryAcquire()

--- a/Sources/PipelineKitSecurity/Middleware/Authentication/AuthenticationMiddleware.swift
+++ b/Sources/PipelineKitSecurity/Middleware/Authentication/AuthenticationMiddleware.swift
@@ -19,18 +19,23 @@ import PipelineKit
 /// ## Usage
 ///
 /// ```swift
+/// enum AuthError: Error {
+///     case missingCredentials
+///     case userInactive
+/// }
+///
 /// let authMiddleware = AuthenticationMiddleware { userId in
 ///     // Validate user credentials
 ///     guard let userId = userId else {
-///         throw AuthenticationError.missingCredentials
+///         throw AuthError.missingCredentials
 ///     }
-///     
+///
 ///     // Verify user exists and is active
 ///     let user = try await userService.verify(userId)
 ///     guard user.isActive else {
-///         throw AuthenticationError.userInactive
+///         throw AuthError.userInactive
 ///     }
-///     
+///
 ///     return user.id
 /// }
 ///
@@ -54,7 +59,7 @@ import PipelineKit
 /// - Note: This middleware has `.authentication` priority, ensuring it runs
 ///   before authorization and business logic middleware.
 ///
-/// - SeeAlso: `AuthenticationError`, `Middleware`
+/// - SeeAlso: `Middleware`
 /// AuthenticationMiddleware conforms to NextGuardWarningSuppressing because it
 /// intentionally short-circuits the pipeline by throwing when authentication fails,
 /// without calling `next()`. This is expected behavior for security middleware.
@@ -69,7 +74,7 @@ public struct AuthenticationMiddleware: Middleware, NextGuardWarningSuppressing 
     ///
     /// - Parameter authenticate: An async function that validates user credentials.
     ///   It receives an optional user ID and returns the validated user ID.
-    ///   Should throw `AuthenticationError` for authentication failures.
+    ///   Should throw your own error type for authentication failures; the middleware rethrows it unchanged.
     public init(authenticate: @escaping @Sendable (String?) async throws -> String) {
         self.authenticate = authenticate
     }
@@ -83,8 +88,7 @@ public struct AuthenticationMiddleware: Middleware, NextGuardWarningSuppressing 
     ///
     /// - Returns: The result from the command execution chain
     ///
-    /// - Throws: `AuthenticationError` if authentication fails, or any error
-    ///   from the downstream chain
+    /// - Throws: Whatever your `authenticate` closure throws when authentication fails, or any error from the downstream chain.
     public func execute<T: Command>(
         _ command: T,
         context: CommandContext,

--- a/Tests/PipelineKitResilienceTests/PartitionedBulkheadConfigurationTests.swift
+++ b/Tests/PipelineKitResilienceTests/PartitionedBulkheadConfigurationTests.swift
@@ -1,0 +1,44 @@
+//
+//  PartitionedBulkheadConfigurationTests.swift
+//  PipelineKit
+//
+//  reservedCapacityPercentage is the truthful name for the value historically
+//  exposed as maxBorrowPercentage (which was always the lender's RESERVED
+//  share, not a borrowing cap). The old name and init survive as deprecated
+//  forwarding shims until 0.6.
+//
+
+import XCTest
+@testable import PipelineKitCore
+import PipelineKitResilience
+
+final class PartitionedBulkheadConfigurationTests: XCTestCase {
+    private static let partitions = [
+        "default": PartitionedBulkheadMiddleware.PartitionConfig(capacity: 10)
+    ]
+
+    func testReservedCapacityPercentageIsPrimaryAndDefaultsUnchanged() {
+        let config = PartitionedBulkheadMiddleware.Configuration(
+            partitions: Self.partitions,
+            partitionExtractor: { _, _ in "default" }
+        )
+        XCTAssertEqual(config.reservedCapacityPercentage, 0.2, accuracy: .ulpOfOne)
+    }
+
+    func testDeprecatedAliasAndInitForwardToReservedCapacityPercentage() {
+        let config = PartitionedBulkheadMiddleware.Configuration(
+            partitions: Self.partitions,
+            partitionExtractor: { _, _ in "default" },
+            reservedCapacityPercentage: 0.5
+        )
+        // Deprecation warnings below are expected: the test pins the shims.
+        XCTAssertEqual(config.maxBorrowPercentage, 0.5, accuracy: .ulpOfOne)
+
+        let legacy = PartitionedBulkheadMiddleware.Configuration(
+            partitions: Self.partitions,
+            partitionExtractor: { _, _ in "default" },
+            maxBorrowPercentage: 0.3
+        )
+        XCTAssertEqual(legacy.reservedCapacityPercentage, 0.3, accuracy: .ulpOfOne)
+    }
+}

--- a/docs/guides/resilience-patterns.md
+++ b/docs/guides/resilience-patterns.md
@@ -115,7 +115,9 @@ every tag still contends for the same single `maxConcurrency` semaphore, so
 one noisy tenant can still starve the others. `PartitionedBulkheadMiddleware`
 gives each declared partition its own capacity, and its `partitionExtractor`
 also receives both the command and the `CommandContext` (unlike `.tagged`'s
-command-only key extractor).
+command-only key extractor). As of 0.5.4, `.tagged` is deprecated and will
+be removed in 0.6; use `PartitionedBulkheadMiddleware` with `allowBorrowing:
+false` for real per-tenant capacity.
 
 `PartitionedBulkheadMiddleware` requires every partition to be declared up
 front in `partitions`, so this fits a small, known set of tenants (or tenant
@@ -287,7 +289,9 @@ try await pipeline.addMiddleware(BackPressureMiddleware(
 - `.tagged` isolation mode records the tag as context metadata (`bulkheadTag`)
   for observability only — it does **not** give each tag its own capacity; all
   tags still contend for the same shared limit (tracked in
-  [#86](https://github.com/gifton/PipelineKit/issues/86))
+  [#86](https://github.com/gifton/PipelineKit/issues/86)). As of 0.5.4, `.tagged`
+  is deprecated and will be removed in 0.6; use `PartitionedBulkheadMiddleware`
+  with `allowBorrowing: false` for real per-tenant capacity.
 - For true per-partition isolation (e.g. multi-tenant systems), use
   `PartitionedBulkheadMiddleware` instead (see "Multi-Tenant Workloads" above)
 


### PR DESCRIPTION
Audit findings F-24, F-22 (#86), F-27c. Closes #86.

- `maxBorrowPercentage` → `reservedCapacityPercentage` with deprecated forwarding alias + init overload (semantics unchanged; the old name said the opposite of what the value does).
- `IsolationMode.tagged` deprecated: all tags share one semaphore; real per-tenant capacity is `PartitionedBulkheadMiddleware(allowBorrowing: false)`. Removal in 0.6. One intentional internal deprecation warning at the dispatch match site.
- `AuthenticationMiddleware` docs stop referencing the nonexistent `AuthenticationError`.

Maintainer gate: full unfiltered suite in Xcode before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)