### PR TITLE
refactor(nextguard): throw-aware deinit diagnostics; narrow NextGuardWarningSuppressing to return-based short-circuits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `NextGuard` debug diagnostics are now error-exit aware: middleware that
+  throws without calling `next()` no longer emits the false "deallocated
+  without calling next()" warning — the middleware chain now marks the guard
+  before rethrowing. `NextGuardWarningSuppressing` is only needed for
+  middleware that *returns* a result without calling `next()` on a normal
+  path (e.g. cache hits). Debug-only; release builds are unchanged. ([#97])
+
+### Removed
+- `NextGuardWarningSuppressing` conformance removed from the twelve
+  throw-based short-circuiting middlewares (`BackPressureMiddleware`,
+  `CircuitBreakerMiddleware`, `RateLimitingMiddleware`,
+  `EnhancedRateLimitingMiddleware`, `BulkheadMiddleware`,
+  `PartitionedBulkheadMiddleware`, `HealthCheckMiddleware`,
+  `ValidationMiddleware`, `SecurityPolicyMiddleware`,
+  `AuthenticationMiddleware`, `AuthorizationMiddleware`,
+  `MockAuthenticationMiddleware`), re-arming the dropped-chain diagnostic
+  for those types. Observable only to code checking
+  `is any NextGuardWarningSuppressing`; the cache middlewares keep the
+  conformance. ([#97])
+
 ## [0.5.4] - 2026-08-15
 
 ### Deprecated
@@ -362,3 +383,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#86]: https://github.com/gifton/PipelineKit/issues/86
 [#88]: https://github.com/gifton/PipelineKit/issues/88
 [#92]: https://github.com/gifton/PipelineKit/issues/92
+[#97]: https://github.com/gifton/PipelineKit/issues/97

--- a/Examples/Sources/AdvancedExample/main.swift
+++ b/Examples/Sources/AdvancedExample/main.swift
@@ -41,7 +41,7 @@ struct SubmitOrderHandler: CommandHandler {
 
 // MARK: - Custom middleware
 
-struct OrderValidationMiddleware: Middleware, NextGuardWarningSuppressing {
+struct OrderValidationMiddleware: Middleware {
     let priority = ExecutionPriority.validation
 
     func execute<T: Command>(

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The main module provides the core pipeline implementation with production-ready 
 - `PipelineBuilder` – fluent builder for assembling pipelines
 - `SimpleSemaphore` – basic concurrency control (acquire is `async throws`)
 - `NextGuard` – ensures middleware `next` is called exactly once
-- `NextGuardWarningSuppressing` – opt‑in to suppress debug‑only warnings for intentional short‑circuits (e.g., cache hits)
+- `NextGuardWarningSuppressing` – opt‑in to suppress debug‑only deinit warnings only for middleware that returns a result without calling `next()` (e.g., cache hits); since 0.6, throw‑based short‑circuits are detected automatically and don't need it
 
 SwiftLog is used for internal logging; on Apple, you can bootstrap `swift-log-oslog` for OSLog output.
 
@@ -916,7 +916,7 @@ PipelineKit is released under the MIT License. See [LICENSE](LICENSE) for detail
 - NextGuard safety:
   - Default: ensures `next` is called exactly once; throws on multiple/concurrent calls.
   - `UnsafeMiddleware`: opt‑out for custom patterns (use with care).
-  - `NextGuardWarningSuppressing`: suppresses debug‑only deinit warnings for intentional short‑circuits (e.g., cache hits).
+  - `NextGuardWarningSuppressing`: suppresses debug‑only deinit warnings only for middleware that returns a result without calling `next()` (e.g., cache hits). Since 0.6, throw‑based short‑circuits (rejections, validation failures, timeouts/cancellation) are detected automatically by the chain and don't need this.
 - AnySendable: type‑erased Sendable value container (not Equatable/Hashable by design). Extract concrete values via `get(_:)` to compare.
 - Platform support:
   - Apple platforms fully supported per Package.swift.

--- a/Sources/PipelineKit/Concurrency/Safety/NextGuard.swift
+++ b/Sources/PipelineKit/Concurrency/Safety/NextGuard.swift
@@ -35,7 +35,17 @@ public final class NextGuard<T: Command>: Sendable {
     
     /// Whether to suppress deinit warnings when `next` was never called
     private let suppressDeinitWarning: Bool
-    
+
+    #if DEBUG
+    /// Set when the guarded middleware invocation exited by throwing.
+    ///
+    /// An error exit is always caller-visible — never a silently dropped
+    /// chain — so the deinit warning would be noise. The chain builder marks
+    /// the guard before rethrowing. Debug-only: release builds carry no
+    /// deinit diagnostics.
+    private let errorExit = ManagedAtomic<Bool>(false)
+    #endif
+
     /// Creates a new NextGuard wrapping the given next closure.
     ///
     /// - Parameters:
@@ -106,7 +116,19 @@ public final class NextGuard<T: Command>: Sendable {
     ) async throws -> T.Result {
         try await self(command, context)
     }
-    
+
+    /// Records that the middleware invocation guarded by this instance exited
+    /// by throwing, suppressing the debug never-called-next deinit warning.
+    ///
+    /// Called by `MiddlewareChainBuilder` before rethrowing. A throw is always
+    /// observed by the caller, so it can never be the silently-dropped-chain
+    /// bug the warning exists to catch. No-op in release builds.
+    func markErrorExit() {
+        #if DEBUG
+        errorExit.store(true, ordering: .relaxed)
+        #endif
+    }
+
     #if DEBUG
     /// Debug-only check that next was called before deallocation
     deinit {
@@ -118,6 +140,11 @@ public final class NextGuard<T: Command>: Sendable {
             // Check if task was cancelled
             if Task.isCancelled {
                 return // Cancellation is acceptable
+            }
+            // Error exits are marked by the chain builder and are
+            // caller-visible — never a silent drop
+            if errorExit.load(ordering: .relaxed) {
+                return
             }
             // Respect per-instance suppression
             if suppressDeinitWarning {

--- a/Sources/PipelineKit/Pipeline/MiddlewareChainBuilder.swift
+++ b/Sources/PipelineKit/Pipeline/MiddlewareChainBuilder.swift
@@ -45,20 +45,25 @@ enum MiddlewareChainBuilder {
                         }
                     }
 
-                    // Create NextGuard lazily, only when middleware will actually execute
-                    let wrappedNext: @Sendable (T, CommandContext) async throws -> T.Result
+                    // Unsafe middleware opts out of NextGuard entirely
                     if isUnsafe {
-                        wrappedNext = previous
-                    } else {
-                        let nextGuard = NextGuard<T>(
-                            previous,
-                            identifier: middlewareName,
-                            suppressDeinitWarning: suppress
-                        )
-                        wrappedNext = nextGuard.callAsFunction
+                        return try await middleware.execute(cmd, context: ctx, next: previous)
                     }
 
-                    return try await middleware.execute(cmd, context: ctx, next: wrappedNext)
+                    // Create NextGuard lazily, only when middleware will actually execute
+                    let nextGuard = NextGuard<T>(
+                        previous,
+                        identifier: middlewareName,
+                        suppressDeinitWarning: suppress
+                    )
+                    do {
+                        return try await middleware.execute(cmd, context: ctx, next: nextGuard.callAsFunction)
+                    } catch {
+                        // An error exit is caller-visible — never a silently
+                        // dropped chain; keep the debug deinit warning quiet
+                        nextGuard.markErrorExit()
+                        throw error
+                    }
                 }
             }
         }
@@ -95,20 +100,25 @@ enum MiddlewareChainBuilder {
                     }
                 }
 
-                // Create NextGuard lazily, only when middleware will actually execute
-                let wrappedNext: @Sendable (T, CommandContext) async throws -> T.Result
+                // Unsafe middleware opts out of NextGuard entirely
                 if isUnsafe {
-                    wrappedNext = previous
-                } else {
-                    let nextGuard = NextGuard<T>(
-                        previous,
-                        identifier: middlewareName,
-                        suppressDeinitWarning: suppress
-                    )
-                    wrappedNext = nextGuard.callAsFunction
+                    return try await middleware.execute(cmd, context: ctx, next: previous)
                 }
 
-                return try await middleware.execute(cmd, context: ctx, next: wrappedNext)
+                // Create NextGuard lazily, only when middleware will actually execute
+                let nextGuard = NextGuard<T>(
+                    previous,
+                    identifier: middlewareName,
+                    suppressDeinitWarning: suppress
+                )
+                do {
+                    return try await middleware.execute(cmd, context: ctx, next: nextGuard.callAsFunction)
+                } catch {
+                    // An error exit is caller-visible — never a silently
+                    // dropped chain; keep the debug deinit warning quiet
+                    nextGuard.markErrorExit()
+                    throw error
+                }
             }
         }
         return chain

--- a/Sources/PipelineKitCore/Middleware/Middleware.swift
+++ b/Sources/PipelineKitCore/Middleware/Middleware.swift
@@ -224,10 +224,14 @@ public protocol UnsafeMiddleware: Middleware {
 
 /// A marker protocol for middleware that want to suppress NextGuard deinit warnings.
 ///
-/// Conform when middleware may intentionally not call `next` under normal,
-/// non-error conditions and the lack of a call should not surface as a debug warning
-/// (for example, caching or fast-path short-circuiting). This affects only debug
-/// deinit warnings; it does not change NextGuard's runtime safety checks.
+/// Conform only when middleware may intentionally RETURN a result without
+/// calling `next` on a normal, non-error path (for example, serving a cache
+/// hit). Middleware that short-circuits by THROWING does not need this: the
+/// chain builder detects error exits and suppresses the debug warning
+/// automatically — a throw is always caller-visible, so conforming a
+/// throw-based middleware only disarms the diagnostic that catches a
+/// genuinely dropped chain. This affects only debug deinit warnings; it does
+/// not change NextGuard's runtime safety checks.
 public protocol NextGuardWarningSuppressing: Middleware {
     // Marker protocol - no additional requirements
 }

--- a/Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift
@@ -57,7 +57,7 @@ import _ResilienceFoundation
 /// 3. Bulkhead (isolate resources)
 /// 4. Timeout (bound execution time)
 /// 5. Retry (handle transient failures)
-public struct BulkheadMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct BulkheadMiddleware: Middleware {
     public let priority: ExecutionPriority = .resilience
 
     // MARK: - Configuration

--- a/Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift
@@ -30,7 +30,7 @@ import os
 ///   - Network operations: 5-10 failures before opening
 ///   - Database operations: 2-5 failures before opening
 ///   - Critical services: 1-3 failures with longer recovery timeout
-public struct CircuitBreakerMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct CircuitBreakerMiddleware: Middleware {
     public let priority: ExecutionPriority = .resilience
     
     // MARK: - Internal State

--- a/Sources/PipelineKitResilienceCircuitBreaker/HealthCheckMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/HealthCheckMiddleware.swift
@@ -30,7 +30,7 @@ import PipelineKitCore
 /// )
 /// pipeline.use(middleware)
 /// ```
-public struct HealthCheckMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct HealthCheckMiddleware: Middleware {
     /// Runs in the `.resilience` priority band, alongside circuit breakers, retries,
     /// and timeouts.
     public let priority: ExecutionPriority = .resilience

--- a/Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift
+++ b/Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift
@@ -31,7 +31,7 @@ import PipelineKitCore
 ///     }
 /// )
 /// ```
-public struct PartitionedBulkheadMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct PartitionedBulkheadMiddleware: Middleware {
     /// Runs in the `.resilience` priority band, alongside circuit breakers, retries,
     /// and timeouts.
     public let priority: ExecutionPriority = .resilience

--- a/Sources/PipelineKitResilienceCore/BackPressureMiddleware.swift
+++ b/Sources/PipelineKitResilienceCore/BackPressureMiddleware.swift
@@ -4,7 +4,7 @@ import Atomics
 import _ResilienceFoundation
 
 /// Middleware that enforces back-pressure limits on command execution
-public actor BackPressureMiddleware: Middleware, NextGuardWarningSuppressing {
+public actor BackPressureMiddleware: Middleware {
     public let priority: ExecutionPriority = .preProcessing
     
     private let semaphore: BackPressureSemaphore

--- a/Sources/PipelineKitResilienceRateLimiting/EnhancedRateLimitingMiddleware.swift
+++ b/Sources/PipelineKitResilienceRateLimiting/EnhancedRateLimitingMiddleware.swift
@@ -25,7 +25,7 @@ import PipelineKit
 ///     }
 /// )
 /// ```
-public struct EnhancedRateLimitingMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct EnhancedRateLimitingMiddleware: Middleware {
     public let priority: ExecutionPriority = .authentication
     private let limiter: RateLimiter
     private let identifierExtractor: @Sendable (any Command, CommandContext) async -> String

--- a/Sources/PipelineKitResilienceRateLimiting/RateLimitingMiddleware.swift
+++ b/Sources/PipelineKitResilienceRateLimiting/RateLimitingMiddleware.swift
@@ -11,7 +11,7 @@ import PipelineKit
 /// )
 /// let middleware = RateLimitingMiddleware(limiter: limiter)
 /// ```
-public struct RateLimitingMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct RateLimitingMiddleware: Middleware {
     public let priority: ExecutionPriority = .authentication
     private let limiter: RateLimiter
     private let identifierExtractor: @Sendable (any Command, CommandContext) async -> String

--- a/Sources/PipelineKitSecurity/Middleware/Authentication/AuthenticationMiddleware.swift
+++ b/Sources/PipelineKitSecurity/Middleware/Authentication/AuthenticationMiddleware.swift
@@ -60,10 +60,7 @@ import PipelineKit
 ///   before authorization and business logic middleware.
 ///
 /// - SeeAlso: `Middleware`
-/// AuthenticationMiddleware conforms to NextGuardWarningSuppressing because it
-/// intentionally short-circuits the pipeline by throwing when authentication fails,
-/// without calling `next()`. This is expected behavior for security middleware.
-public struct AuthenticationMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct AuthenticationMiddleware: Middleware {
     /// Priority ensures authentication happens early in the pipeline.
     public let priority: ExecutionPriority = .authentication
     

--- a/Sources/PipelineKitSecurity/Middleware/Authorization/AuthorizationMiddleware.swift
+++ b/Sources/PipelineKitSecurity/Middleware/Authorization/AuthorizationMiddleware.swift
@@ -3,10 +3,7 @@ import PipelineKit
 
 /// Authorization middleware with role-based access control.
 ///
-/// This middleware conforms to `NextGuardWarningSuppressing` because it
-/// intentionally short-circuits the pipeline by throwing when authorization fails,
-/// without calling `next()`. This is expected behavior for security middleware.
-public struct AuthorizationMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct AuthorizationMiddleware: Middleware {
     public let priority: ExecutionPriority = .validation
     private let requiredRoles: Set<String>
     private let getUserRoles: @Sendable (String) async throws -> Set<String>

--- a/Sources/PipelineKitSecurity/Middleware/Validation/ValidationMiddleware.swift
+++ b/Sources/PipelineKitSecurity/Middleware/Validation/ValidationMiddleware.swift
@@ -21,7 +21,7 @@ import PipelineKit
 ///     priority: ExecutionPriority.validation.rawValue
 /// )
 /// ```
-public struct ValidationMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct ValidationMiddleware: Middleware {
     public let priority: ExecutionPriority = .validation
     
     public init() {}

--- a/Sources/PipelineKitSecurity/Policies/SecurityPolicy.swift
+++ b/Sources/PipelineKitSecurity/Policies/SecurityPolicy.swift
@@ -69,7 +69,7 @@ public struct SecurityPolicy: Sendable {
 /// 
 /// This middleware applies configured security policies to all commands,
 /// providing an additional layer of protection beyond basic validation.
-public struct SecurityPolicyMiddleware: Middleware, NextGuardWarningSuppressing {
+public struct SecurityPolicyMiddleware: Middleware {
     public let priority: ExecutionPriority = .custom
     private let policy: SecurityPolicy
     

--- a/Sources/PipelineKitTestSupport/Mocks/MockTypes.swift
+++ b/Sources/PipelineKitTestSupport/Mocks/MockTypes.swift
@@ -32,7 +32,7 @@ public final class MockCommandHandler: CommandHandler {
 
 // MARK: - Mock Middleware
 
-public final class MockAuthenticationMiddleware: Middleware, NextGuardWarningSuppressing, Sendable {
+public final class MockAuthenticationMiddleware: Middleware, Sendable {
     public let priority = ExecutionPriority.authentication
     
     public init() {}

--- a/Tests/PipelineKitCacheTests/NextGuardSuppressionTests.swift
+++ b/Tests/PipelineKitCacheTests/NextGuardSuppressionTests.swift
@@ -44,4 +44,15 @@ final class NextGuardSuppressionTests: XCTestCase {
         let warnings = await collector.snapshot()
         XCTAssertTrue(warnings.isEmpty, "Expected no NextGuard warnings, got: \(warnings)")
     }
+
+    /// Pins that the cache middlewares KEEP NextGuardWarningSuppressing (#97):
+    /// they return a result without calling next() on a cache hit — the one
+    /// legitimate use of the marker after the chain builder learned to detect
+    /// error exits on its own.
+    func testCacheMiddlewaresRetainNextGuardSuppression() {
+        XCTAssertTrue(CachingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(SimpleCachingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(CachedMiddleware<CachingMiddleware>.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(ConditionalCachedMiddleware<CachingMiddleware>.self is any NextGuardWarningSuppressing.Type)
+    }
 }

--- a/Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift
+++ b/Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift
@@ -2,11 +2,10 @@
 //  NextGuardSuppressionConformanceTests.swift
 //  PipelineKit
 //
-//  Middlewares that intentionally short-circuit (throw a rejection or return
-//  without calling next) must conform to NextGuardWarningSuppressing so their
-//  normal rejection paths don't emit false debug "deallocated without calling
-//  next()" warnings. Metatype assertions pin the contract without needing to
-//  construct configurations.
+//  Pins the #97 re-arm: throw-based short-circuiting middleware must NOT
+//  conform to NextGuardWarningSuppressing. The chain builder detects error
+//  exits itself since 0.6, and conforming would disarm the debug diagnostic
+//  that catches a genuinely dropped chain (a silent return without next()).
 //
 
 import XCTest
@@ -14,13 +13,13 @@ import PipelineKitCore
 import PipelineKitResilience
 
 final class NextGuardSuppressionConformanceTests: XCTestCase {
-    func testShortCircuitingResilienceMiddlewaresSuppressNextGuardWarnings() {
-        XCTAssertTrue(BackPressureMiddleware.self is any NextGuardWarningSuppressing.Type)
-        XCTAssertTrue(CircuitBreakerMiddleware.self is any NextGuardWarningSuppressing.Type)
-        XCTAssertTrue(RateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
-        XCTAssertTrue(EnhancedRateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
-        XCTAssertTrue(BulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
-        XCTAssertTrue(PartitionedBulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
-        XCTAssertTrue(HealthCheckMiddleware.self is any NextGuardWarningSuppressing.Type)
+    func testThrowBasedResilienceMiddlewaresDoNotSuppressNextGuardWarnings() {
+        XCTAssertFalse(BackPressureMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(CircuitBreakerMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(RateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(EnhancedRateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(BulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(PartitionedBulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(HealthCheckMiddleware.self is any NextGuardWarningSuppressing.Type)
     }
 }

--- a/Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift
+++ b/Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift
@@ -1,10 +1,20 @@
+//
+//  NextGuardSuppressionConformanceTests.swift
+//  PipelineKit
+//
+//  Pins the #97 re-arm for security middleware: these types short-circuit
+//  only by throwing, which the chain builder detects since 0.6.
+//
+
 import XCTest
 import PipelineKitCore
 import PipelineKitSecurity
 
 final class NextGuardSuppressionConformanceTests: XCTestCase {
-    func testShortCircuitingSecurityMiddlewaresSuppressNextGuardWarnings() {
-        XCTAssertTrue(ValidationMiddleware.self is any NextGuardWarningSuppressing.Type)
-        XCTAssertTrue(SecurityPolicyMiddleware.self is any NextGuardWarningSuppressing.Type)
+    func testThrowBasedSecurityMiddlewaresDoNotSuppressNextGuardWarnings() {
+        XCTAssertFalse(ValidationMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(SecurityPolicyMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(AuthenticationMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(AuthorizationMiddleware.self is any NextGuardWarningSuppressing.Type)
     }
 }

--- a/Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift
+++ b/Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import PipelineKitCore
 import PipelineKitSecurity
+import PipelineKitTestSupport
 
 final class NextGuardSuppressionConformanceTests: XCTestCase {
     func testThrowBasedSecurityMiddlewaresDoNotSuppressNextGuardWarnings() {
@@ -16,5 +17,6 @@ final class NextGuardSuppressionConformanceTests: XCTestCase {
         XCTAssertFalse(SecurityPolicyMiddleware.self is any NextGuardWarningSuppressing.Type)
         XCTAssertFalse(AuthenticationMiddleware.self is any NextGuardWarningSuppressing.Type)
         XCTAssertFalse(AuthorizationMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(MockAuthenticationMiddleware.self is any NextGuardWarningSuppressing.Type)
     }
 }

--- a/Tests/PipelineKitTests/Safety/NextGuardErrorExitTests.swift
+++ b/Tests/PipelineKitTests/Safety/NextGuardErrorExitTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import PipelineKit
+@testable import PipelineKitCore
+
+/// Verifies NextGuard's debug deinit diagnostics are error-exit aware (#97):
+/// middleware that THROWS without calling next() is caller-visible and must
+/// not warn; middleware that silently RETURNS without calling next() is the
+/// dropped-chain bug class the warning exists for and must still warn.
+final class NextGuardErrorExitTests: XCTestCase {
+    private struct TestCommand: Command {
+        typealias Result = String
+        let value: String
+    }
+
+    private final class EchoHandler: CommandHandler {
+        typealias CommandType = TestCommand
+        func handle(_ command: TestCommand, context: CommandContext) async throws -> String {
+            command.value
+        }
+    }
+
+    private struct TestFailure: Error {}
+
+    /// Throw-based short-circuit that deliberately does NOT conform to
+    /// NextGuardWarningSuppressing — the chain builder detects the error
+    /// exit on its own.
+    private struct ThrowingMiddleware: Middleware {
+        func execute<T: Command>(
+            _ command: T,
+            context: CommandContext,
+            next: @escaping MiddlewareNext<T>
+        ) async throws -> T.Result {
+            throw TestFailure()
+        }
+    }
+
+    /// Silently returns without calling next() and does NOT conform to
+    /// NextGuardWarningSuppressing — the dropped-chain bug class. Only used
+    /// with TestCommand, whose Result is String, so the cast always succeeds.
+    private struct SwallowingMiddleware: Middleware {
+        func execute<T: Command>(
+            _ command: T,
+            context: CommandContext,
+            next: @escaping MiddlewareNext<T>
+        ) async throws -> T.Result {
+            // swiftlint:disable:next force_cast
+            return "swallowed" as! T.Result
+        }
+    }
+
+    /// Synchronous warning sink. NextGuard's deinit calls the handler
+    /// synchronously and every guard is released before pipeline.execute
+    /// returns, so assertions after the await are safe. (Deliberately NOT
+    /// the async-actor pattern from PipelineKitCacheTests — that hop races
+    /// the snapshot.)
+    private final class WarningSink: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [String] = []
+        func add(_ message: String) {
+            lock.lock()
+            storage.append(message)
+            lock.unlock()
+        }
+        var items: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    private var sink: WarningSink!
+
+    override func setUp() {
+        super.setUp()
+        sink = WarningSink()
+        let sink = self.sink!
+        NextGuardConfiguration.setWarningHandler { message in
+            sink.add(message)
+        }
+        NextGuardConfiguration.shared.emitWarnings = true
+    }
+
+    override func tearDown() {
+        NextGuardConfiguration.shared.warningHandler = nil
+        NextGuardConfiguration.shared.emitWarnings = true
+        sink = nil
+        super.tearDown()
+    }
+
+    // MARK: - Unit level
+
+    #if DEBUG
+    func testUncalledGuardWarnsWithoutMark() {
+        var nextGuard: NextGuard<TestCommand>? = NextGuard(
+            { command, _ in command.value },
+            identifier: "error-exit-unit-test"
+        )
+        XCTAssertNotNil(nextGuard)
+        nextGuard = nil // deinit fires synchronously here
+        XCTAssertEqual(sink.items.count, 1, "uncalled, unmarked guard must warn")
+        XCTAssertTrue(sink.items.first?.contains("error-exit-unit-test") ?? false)
+    }
+    #endif
+
+    func testMarkErrorExitSuppressesDeinitWarning() {
+        var nextGuard: NextGuard<TestCommand>? = NextGuard(
+            { command, _ in command.value },
+            identifier: "error-exit-unit-test"
+        )
+        nextGuard?.markErrorExit()
+        nextGuard = nil
+        XCTAssertTrue(sink.items.isEmpty, "marked guard must not warn: \(sink.items)")
+    }
+
+    // MARK: - Chain level
+
+    func testThrowingMiddlewareWithoutMarkerEmitsNoWarning() async throws {
+        let pipeline = StandardPipeline(handler: EchoHandler())
+        try await pipeline.addMiddleware(ThrowingMiddleware())
+
+        do {
+            _ = try await pipeline.execute(TestCommand(value: "x"), context: CommandContext())
+            XCTFail("expected TestFailure")
+        } catch is TestFailure {
+            // expected: rejection propagates unchanged
+        }
+
+        XCTAssertTrue(
+            sink.items.isEmpty,
+            "error exits are caller-visible and must not warn: \(sink.items)"
+        )
+    }
+
+    #if DEBUG
+    func testSilentReturnWithoutMarkerStillWarns() async throws {
+        let pipeline = StandardPipeline(handler: EchoHandler())
+        try await pipeline.addMiddleware(SwallowingMiddleware())
+
+        let result = try await pipeline.execute(TestCommand(value: "x"), context: CommandContext())
+        XCTAssertEqual(result, "swallowed")
+
+        XCTAssertEqual(
+            sink.items.count, 1,
+            "a silent return without next() is a dropped chain and must warn: \(sink.items)"
+        )
+        XCTAssertTrue(sink.items.first?.contains("SwallowingMiddleware") ?? false)
+    }
+    #endif
+
+    /// Control: well-behaved middleware calling next() exactly once never warns.
+    func testWellBehavedMiddlewareEmitsNoWarning() async throws {
+        struct PassthroughMiddleware: Middleware {
+            func execute<T: Command>(
+                _ command: T,
+                context: CommandContext,
+                next: @escaping MiddlewareNext<T>
+            ) async throws -> T.Result {
+                try await next(command, context)
+            }
+        }
+        let pipeline = StandardPipeline(handler: EchoHandler())
+        try await pipeline.addMiddleware(PassthroughMiddleware())
+        let result = try await pipeline.execute(TestCommand(value: "ok"), context: CommandContext())
+        XCTAssertEqual(result, "ok")
+        XCTAssertTrue(sink.items.isEmpty)
+    }
+}

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -96,7 +96,7 @@ Command → Pipeline → [Middleware…] → Handler → Result
 - Stable ordering: middleware sorted by ExecutionPriority; ties preserve insertion order
 - Concurrency limits: StandardPipeline can be constructed with maxConcurrency or PipelineOptions
 - Back‑pressure: for advanced scenarios, compose resilience middleware (e.g., bulkhead) from PipelineKitResilience
-- NextGuard: ensures `next` is called exactly once; use UnsafeMiddleware to opt‑out, and NextGuardWarningSuppressing to suppress debug‑only deinit warnings for intentional short‑circuits
+- NextGuard: ensures `next` is called exactly once; use UnsafeMiddleware to opt‑out. NextGuardWarningSuppressing suppresses debug‑only deinit warnings only for middleware that returns a result without calling `next()` on a normal path (e.g., cache hits) — since 0.6, throw‑based short‑circuits are detected automatically and don't need it
 
 ## Caching
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -60,7 +60,7 @@ print("ops/s: \(Int(10_000 / max(duration, 0.0001)))")
 
 - Avoid capturing large objects in closures
 - Use `ExecutionPriority` to enforce sensible order
-- For short‑circuiting middleware (e.g., caching), adopt `NextGuardWarningSuppressing`
+- For middleware that returns a result without calling `next()` (e.g., caching), adopt `NextGuardWarningSuppressing`; since 0.6, throw‑based short‑circuits are detected automatically and don't need it
 
 ## Troubleshooting
 

--- a/docs/internal/NEXTGUARD_CONFIGURATION.md
+++ b/docs/internal/NEXTGUARD_CONFIGURATION.md
@@ -22,7 +22,7 @@ NextGuardConfiguration.setWarningHandler { message in
 
 ### Intentional Short‑Circuiting
 
-If a middleware intentionally short‑circuits without calling `next()` (e.g., cache hit), conform to `NextGuardWarningSuppressing` to suppress debug‑only deinit warnings for that middleware:
+If a middleware intentionally RETURNS a result without calling `next()` on a normal path (e.g., cache hit), conform to `NextGuardWarningSuppressing` to suppress debug‑only deinit warnings for that middleware. Since 0.6, throw‑based short‑circuits (rejections, validation failures, timeouts/cancellation) are detected automatically by the middleware chain and need no conformance:
 
 ```swift
 struct MyCachingMiddleware: Middleware, NextGuardWarningSuppressing {
@@ -57,7 +57,7 @@ NextGuardConfiguration.setWarningHandler { _ in /* no‑op in CI */ }
 ## Best Practices
 
 1. Keep warnings enabled in development; they catch real middleware bugs.
-2. Use `NextGuardWarningSuppressing` for legitimate short‑circuits (e.g., caching, deduplication paths).
+2. Use `NextGuardWarningSuppressing` only for middleware that returns a result without calling `next()` (e.g., caching, deduplication paths); throw‑based short‑circuits are detected automatically since 0.6 and don't need it.
 3. Configure warning handler at app startup; avoid flipping settings during runtime.
 4. In CI, you can silence warnings by setting a no‑op handler.
 

--- a/docs/internal/NEXTGUARD_TIMEOUT_LIMITATION.md
+++ b/docs/internal/NEXTGUARD_TIMEOUT_LIMITATION.md
@@ -58,7 +58,7 @@ Instead of heuristics, PipelineKit uses explicit controls:
 
 1) Keep warnings enabled in development; they catch real bugs (missed/duplicate `next()` calls).
 
-2) For middleware that intentionally short‑circuits (e.g., cache hits), conform to `NextGuardWarningSuppressing` to suppress debug‑only deinit warnings for that middleware.
+2) For middleware that intentionally RETURNS a result without calling `next()` on a normal path (e.g., cache hits), conform to `NextGuardWarningSuppressing` to suppress debug‑only deinit warnings for that middleware. Since 0.6, throw‑based short‑circuits (rejections, validation failures, timeouts/cancellation) are detected automatically by the middleware chain and never need this conformance.
 
 3) In CI or specialized tests, register a no‑op warning handler via `NextGuardConfiguration.setWarningHandler(_:)`.
 

--- a/docs/internal/NEXTGUARD_TIMEOUT_LIMITATION.md
+++ b/docs/internal/NEXTGUARD_TIMEOUT_LIMITATION.md
@@ -1,194 +1,86 @@
-# NextGuard: Deinit‑Time Warning Limitation
+# NextGuard Deinit Diagnostics: Design and History
 
 ## Overview
 
-NextGuard enforces exactly‑once and non‑concurrent `next()` calls at runtime using atomics. In debug builds, it also emits a deinit‑time warning if `next()` was never called. Swift’s cancellation and actor isolation can make deinit timing nondeterministic in exceptional flows (e.g., timeouts). This affects only the warning signal, not runtime correctness.
+`NextGuard` enforces exactly-once and non-concurrent `next()` calls at runtime using
+atomics. In debug builds, it also emits a deinit-time warning if `next()` was never
+called — the signal for a *silently dropped chain* (middleware returned a result
+without invoking downstream). Runtime enforcement is unaffected by anything in this
+document; it concerns only the debug warning.
 
-## The Problem
+This file documents a limitation that existed through 0.5.x, how 0.6 resolved it,
+and the one narrow backstop that remains.
 
-### What NextGuard Does
-`NextGuard` is a safety wrapper that ensures middleware calls its `next()` closure exactly once. It detects three types of violations:
-1. Multiple calls to `next()` 
-2. Concurrent calls to `next()`
-3. Forgetting to call `next()` (detected in debug builds via `deinit`)
+## The constraint
 
-### The Limitation
-When a timeout occurs in the pipeline:
-1. `TimeoutMiddleware` calls `group.cancelAll()` to cancel the task group
-2. The middleware chain is immediately deallocated
-3. `NextGuard.deinit` runs **synchronously** to check if `next()` was called
-4. At this point, `Task.isCancelled` may not yet be `true` because cancellation is cooperative and asynchronous
-5. A deinit‑time warning may be emitted even when the pipeline behaved correctly
+Swift `deinit` is synchronous and has no unwind context: at deallocation time the
+guard cannot tell *why* `next()` was never called —
 
-### Why This Can't Be Easily Fixed
+1. the middleware **threw** (a rejection, a validation failure, a timeout, a
+   cancellation) — deliberate, and always visible to the caller;
+2. the middleware **returned** a result without calling `next()` deliberately
+   (e.g. a cache hit);
+3. the middleware **returned** without calling `next()` by accident — the dropped
+   chain the warning exists to catch.
 
-#### Swift's Actor Model Constraint
-```swift
-// CommandContext is an actor (async access only)
-final class CommandContext: @unchecked Sendable {
-    func getCancellationReason() -> CancellationReason? { ... }
-}
+Only (3) is a bug, but `deinit` alone cannot distinguish the three.
 
-// But NextGuard.deinit is synchronous
-class NextGuard {
-    deinit {
-        // ❌ Can't await here - deinit is synchronous
-        // if await context.getCancellationReason() != nil { ... }
-        
-        // ❌ Task.isCancelled might not be set yet
-        if Task.isCancelled { ... }
-    }
-}
+## The pre-0.6 limitation (historical)
+
+Through 0.5.x, case (1) produced false warnings. The worst instance was timeouts:
+
+```
+T0: timeout duration expires
+T1: TimeoutMiddleware cancels the task group
+T2: middleware tasks unwind; NextGuard.deinit runs synchronously
+T3: Task.isCancelled becomes observable — sometimes after T2 (race)
 ```
 
-#### The Deinit Timing Race
-```
-Timeline of a timeout:
-T0: Timeout duration expires
-T1: group.cancelAll() called
-T2: Middleware tasks begin cleanup
-T3: NextGuard.deinit runs (synchronous)
-T4: Task cancellation propagates (asynchronous)
-T5: Task.isCancelled becomes true (too late!)
-```
+The `Task.isCancelled` check in `deinit` was a heuristic patch for this, and it
+raced. 0.5.4 additionally suppressed rejection-path false warnings by conforming
+nine throw-based middlewares to `NextGuardWarningSuppressing` — which silenced the
+noise but also disarmed the case-(3) diagnostic for those types.
 
-## Recommended Approach
+## The 0.6 resolution
 
-Instead of heuristics, PipelineKit uses explicit controls:
+`deinit` cannot see a throw, but the middleware chain can: `MiddlewareChainBuilder`
+invokes `middleware.execute(...)` with the guard in scope. Since 0.6 it wraps that
+invocation in `do/catch` and calls the guard's internal `markErrorExit()` before
+rethrowing. A marked guard never warns.
 
-1) Keep warnings enabled in development; they catch real bugs (missed/duplicate `next()` calls).
+This resolves case (1) *structurally*, for every middleware, with no conformance:
 
-2) For middleware that intentionally RETURNS a result without calling `next()` on a normal path (e.g., cache hits), conform to `NextGuardWarningSuppressing` to suppress debug‑only deinit warnings for that middleware. Since 0.6, throw‑based short‑circuits (rejections, validation failures, timeouts/cancellation) are detected automatically by the middleware chain and never need this conformance.
+- **Rejections** (circuit breaker open, rate limit, bulkhead full, validation or
+  policy failure) exit by throwing → marked → silent.
+- **Timeouts and cancellation**: structured concurrency is cooperative — a
+  cancelled middleware invocation still runs to completion and surfaces
+  cancellation as a thrown `CancellationError` (or a timeout error), which takes
+  the same marked path. The T2/T3 race above no longer matters on this path,
+  because the mark happens before the rethrow, not in `deinit`.
 
-3) In CI or specialized tests, register a no‑op warning handler via `NextGuardConfiguration.setWarningHandler(_:)`.
+Consequently the `NextGuardWarningSuppressing` marker was removed from all
+throw-only middlewares in 0.6 and is needed **only** for case (2): middleware that
+intentionally returns a result without calling `next()` on a normal path (the
+cache middlewares). For everything else the warning is now high-signal: if it
+fires, the middleware returned without calling `next()` and without throwing —
+case (3), a genuine dropped chain.
 
-## Impact Assessment
+## What remains
 
-### For Package Users
+- **The `Task.isCancelled` deinit check is retained as a backstop** for guards
+  that deallocate on a cancelled task without their invocation exiting through
+  the builder's catch (e.g. a guard released during teardown before the
+  middleware body ran). Its original race is unchanged but now mostly moot: the
+  common cancellation paths are handled by the throw-mark, which is
+  race-free.
+- **`deinit` still cannot distinguish (2) from (3)** — that is inherent. The
+  marker protocol is the per-type declaration that closes the gap, and it should
+  stay confined to return-based short-circuits so case (3) stays armed everywhere
+  else.
 
-#### Severity: **LOW to MEDIUM**
+## Configuration
 
-The limitation affects **developer experience**, not runtime behavior:
-
-| Aspect | Impact | Severity |
-|--------|--------|----------|
-| **Runtime Behavior** | None - code executes correctly | ✅ None |
-| **Data Integrity** | No corruption or loss | ✅ None |
-| **Performance** | No overhead | ✅ None |
-| **Security** | No vulnerabilities | ✅ None |
-| **Developer Experience** | False warnings in logs | ⚠️ Medium |
-| **Debugging** | Harder to identify real bugs | ⚠️ Medium |
-| **Testing** | Potential flaky tests | ⚠️ Low |
-
-### Real-World Scenarios
-
-#### Scenario 1: Normal Development
-```swift
-// Developer implements custom timeout middleware
-class CustomDeadlineMiddleware: Middleware {
-    func execute(...) {
-        // When this times out, logs show:
-        // ⚠️ WARNING: NextGuard(CustomDeadlineMiddleware) deallocated without calling next()
-        // Developer wastes time investigating a non-issue
-    }
-}
-```
-
-#### Scenario 2: Production Monitoring
-```swift
-// If warnings are logged in production:
-// - Log aggregation systems get polluted
-// - May trigger false alerts
-// - Team develops "warning fatigue"
-// - Real bugs might be ignored
-```
-
-#### Scenario 3: CI/CD Pipeline
-```swift
-// Tests might fail intermittently:
-// - Pass on fast machines (Task.isCancelled sets quickly)
-// - Fail on slow CI runners (race condition loses)
-// - Inconsistent results frustrate team
-```
-
-### Who Is Affected?
-
-1. **Library Users (Low Impact)**
-   - See occasional false warnings
-   - Can disable warnings in production
-   - Timeouts still work correctly
-
-2. **Library Developers (Medium Impact)**
-   - Must maintain brittle string heuristics
-   - Can't write robust tests for timeout scenarios
-   - Technical debt accumulates
-
-3. **Large Teams (Medium Impact)**
-   - Must coordinate naming conventions
-   - New developers need education about the limitation
-   - Code reviews must catch naming issues
-
-## Is This Worth Fixing?
-
-### Arguments AGAINST Heuristics
-
-1. **It's a Swift limitation, not a PipelineKit bug**
-   - This is a fundamental constraint of Swift's concurrency model
-   - Many Swift libraries face similar issues
-   - Swift Evolution may address this in future versions
-
-2. **The impact is cosmetic**
-   - No runtime errors
-   - No data corruption
-   - Just log noise
-
-3. **Workarounds add complexity**
-   - Global state breaks actor isolation benefits
-   - `@unchecked Sendable` reduces safety
-   - Complex solutions for a minor problem
-
-4. **Time investment vs. benefit**
-   - Significant engineering effort required
-   - Benefits are marginal (cleaner logs)
-   - Could introduce new bugs
-
-### Arguments FOR the Current Approach
-
-1. **Professional polish**
-   - False warnings look unprofessional
-   - Reduces confidence in the library
-   - First impressions matter for adoption
-
-2. **Developer experience**
-   - Warning fatigue is real
-   - Time wasted on false positives adds up
-   - Frustration accumulates over time
-
-3. **Future maintenance**
-   - String heuristics are fragile
-   - Will break with refactoring
-   - Technical debt compounds
-
-## Recommendation
-
-### Current Status: **Known Limitation (Debug‑Only Warning)**
-
-**This limitation is NOT worth extensive engineering effort to fix because:**
-
-1. **Impact is low**: Only affects debug logging, not functionality
-2. **Swift will likely improve**: Future Swift versions may provide better cancellation APIs
-3. **Workarounds are fragile**: Alternative approaches introduce their own problems
-4. **Cost/benefit ratio is poor**: High effort for marginal improvement
-
-### Suggested Approach
-
-1. **Document prominently** ✅ (this document)
-2. **Disable in production**: Only emit warnings in DEBUG builds
-3. **Improve diagnostics gradually**: Enhance documentation and examples as concurrency APIs evolve
-4. **Wait for Swift Evolution**: Monitor proposals for better cancellation handling
-5. **Re-evaluate periodically**: Revisit when Swift adds new concurrency features
-
-### Configuration Options
+Unchanged; debug builds only:
 
 ```swift
 // Enable/disable warnings globally
@@ -200,14 +92,10 @@ NextGuardConfiguration.setWarningHandler { message in
 }
 ```
 
-## Conclusion
-
-This is a **legitimate limitation** imposed by Swift's concurrency model, not a design flaw in PipelineKit. The impact is primarily on developer experience rather than functionality. While frustrating, it's not severe enough to warrant complex workarounds that could introduce worse problems.
-
-**The pragmatic choice is to accept this limitation** for deinit‑time warnings, use explicit suppression for legitimate short‑circuits, and keep runtime safety guarantees intact.
+Release builds carry no deinit diagnostics at all; the marking machinery compiles
+to a no-op.
 
 ---
 
-*Last updated: 2024*  
-*Swift version: 6.0*  
-*Will be revisited when Swift introduces improved cancellation APIs*
+*Last updated: 2026-08 (0.6 error-exit awareness, #97)*
+*Swift version: 6.2*

--- a/docs/superpowers/plans/2026-08-15-nextguard-throw-aware-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-15-nextguard-throw-aware-diagnostics.md
@@ -1,0 +1,610 @@
+# Throw-Aware NextGuard Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make NextGuard's debug deinit warning error-exit aware (the chain builder marks guards when middleware throws), then remove the now-unnecessary `NextGuardWarningSuppressing` conformances from the 12 throw-only middlewares, re-arming the silent-drop diagnostic for them.
+
+**Architecture:** `NextGuard` gains a debug-only atomic flag + internal `markErrorExit()`; `MiddlewareChainBuilder` (both build variants) wraps the middleware invocation in `do/catch` and marks the guard before rethrowing. The marker protocol survives only for return-based short-circuits (the four cache middlewares). Zero new public API; release builds behaviorally identical.
+
+**Tech Stack:** Swift 6.2, swift-atomics (`ManagedAtomic`), XCTest, SwiftPM.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-nextguard-throw-aware-diagnostics-design.md` (issue [#97](https://github.com/gifton/PipelineKit/issues/97))
+
+## Global Constraints
+
+- **Zero new public API**: `markErrorExit()` is `internal` (builder and guard share the `PipelineKit` module).
+- **Release-config test compatibility**: the release workflow runs `swift test -c release`, where `NextGuard`'s `#if DEBUG` deinit does not exist. Every test asserting a warning **IS** emitted must be wrapped in `#if DEBUG` inside the test file. Tests asserting NO warning may stay ungated (vacuous-but-safe in release).
+- **No release-build behavior change**: the flag and all reads/writes are `#if DEBUG`-gated; `markErrorExit()`'s body compiles to a no-op in release.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Run tests via filtered `swift test --filter "<pattern>"` only; the full unfiltered suite is the maintainer's Xcode gate.
+- Never edit `Package.swift`, never push, never open PRs — the controller handles those.
+- Docs must mirror shipped behavior exactly (no stale rationale comments left behind).
+
+---
+
+### Task 1: NextGuard error-exit mechanism + builder marking
+
+**Files:**
+- Modify: `Sources/PipelineKit/Concurrency/Safety/NextGuard.swift`
+- Modify: `Sources/PipelineKit/Pipeline/MiddlewareChainBuilder.swift`
+- Create: `Tests/PipelineKitTests/Safety/NextGuardErrorExitTests.swift`
+
+**Interfaces:**
+- Consumes: existing `NextGuard<T>` (public init `(_:identifier:suppressDeinitWarning:)`), `NextGuardConfiguration.setWarningHandler`, `StandardPipeline(handler:)` / `addMiddleware` / `execute(_:context:)`.
+- Produces: `internal func markErrorExit()` on `NextGuard` (no-op in release) — Task 2's conformance removals depend on the builder calling it on every error exit.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/PipelineKitTests/Safety/NextGuardErrorExitTests.swift` with exactly:
+
+```swift
+import XCTest
+@testable import PipelineKit
+@testable import PipelineKitCore
+
+/// Verifies NextGuard's debug deinit diagnostics are error-exit aware (#97):
+/// middleware that THROWS without calling next() is caller-visible and must
+/// not warn; middleware that silently RETURNS without calling next() is the
+/// dropped-chain bug class the warning exists for and must still warn.
+final class NextGuardErrorExitTests: XCTestCase {
+    private struct TestCommand: Command {
+        typealias Result = String
+        let value: String
+    }
+
+    private final class EchoHandler: CommandHandler {
+        typealias CommandType = TestCommand
+        func handle(_ command: TestCommand, context: CommandContext) async throws -> String {
+            command.value
+        }
+    }
+
+    private struct TestFailure: Error {}
+
+    /// Throw-based short-circuit that deliberately does NOT conform to
+    /// NextGuardWarningSuppressing — the chain builder detects the error
+    /// exit on its own.
+    private struct ThrowingMiddleware: Middleware {
+        func execute<T: Command>(
+            _ command: T,
+            context: CommandContext,
+            next: @escaping MiddlewareNext<T>
+        ) async throws -> T.Result {
+            throw TestFailure()
+        }
+    }
+
+    /// Silently returns without calling next() and does NOT conform to
+    /// NextGuardWarningSuppressing — the dropped-chain bug class. Only used
+    /// with TestCommand, whose Result is String, so the cast always succeeds.
+    private struct SwallowingMiddleware: Middleware {
+        func execute<T: Command>(
+            _ command: T,
+            context: CommandContext,
+            next: @escaping MiddlewareNext<T>
+        ) async throws -> T.Result {
+            // swiftlint:disable:next force_cast
+            return "swallowed" as! T.Result
+        }
+    }
+
+    /// Synchronous warning sink. NextGuard's deinit calls the handler
+    /// synchronously and every guard is released before pipeline.execute
+    /// returns, so assertions after the await are safe. (Deliberately NOT
+    /// the async-actor pattern from PipelineKitCacheTests — that hop races
+    /// the snapshot.)
+    private final class WarningSink: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [String] = []
+        func add(_ message: String) {
+            lock.lock()
+            storage.append(message)
+            lock.unlock()
+        }
+        var items: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    private var sink: WarningSink!
+
+    override func setUp() {
+        super.setUp()
+        sink = WarningSink()
+        let sink = self.sink!
+        NextGuardConfiguration.setWarningHandler { message in
+            sink.add(message)
+        }
+        NextGuardConfiguration.shared.emitWarnings = true
+    }
+
+    override func tearDown() {
+        NextGuardConfiguration.shared.warningHandler = nil
+        NextGuardConfiguration.shared.emitWarnings = true
+        sink = nil
+        super.tearDown()
+    }
+
+    // MARK: - Unit level
+
+    #if DEBUG
+    func testUncalledGuardWarnsWithoutMark() {
+        var nextGuard: NextGuard<TestCommand>? = NextGuard(
+            { command, _ in command.value },
+            identifier: "error-exit-unit-test"
+        )
+        XCTAssertNotNil(nextGuard)
+        nextGuard = nil // deinit fires synchronously here
+        XCTAssertEqual(sink.items.count, 1, "uncalled, unmarked guard must warn")
+        XCTAssertTrue(sink.items.first?.contains("error-exit-unit-test") ?? false)
+    }
+    #endif
+
+    func testMarkErrorExitSuppressesDeinitWarning() {
+        var nextGuard: NextGuard<TestCommand>? = NextGuard(
+            { command, _ in command.value },
+            identifier: "error-exit-unit-test"
+        )
+        nextGuard?.markErrorExit()
+        nextGuard = nil
+        XCTAssertTrue(sink.items.isEmpty, "marked guard must not warn: \(sink.items)")
+    }
+
+    // MARK: - Chain level
+
+    func testThrowingMiddlewareWithoutMarkerEmitsNoWarning() async throws {
+        let pipeline = StandardPipeline(handler: EchoHandler())
+        try await pipeline.addMiddleware(ThrowingMiddleware())
+
+        do {
+            _ = try await pipeline.execute(TestCommand(value: "x"), context: CommandContext())
+            XCTFail("expected TestFailure")
+        } catch is TestFailure {
+            // expected: rejection propagates unchanged
+        }
+
+        XCTAssertTrue(
+            sink.items.isEmpty,
+            "error exits are caller-visible and must not warn: \(sink.items)"
+        )
+    }
+
+    #if DEBUG
+    func testSilentReturnWithoutMarkerStillWarns() async throws {
+        let pipeline = StandardPipeline(handler: EchoHandler())
+        try await pipeline.addMiddleware(SwallowingMiddleware())
+
+        let result = try await pipeline.execute(TestCommand(value: "x"), context: CommandContext())
+        XCTAssertEqual(result, "swallowed")
+
+        XCTAssertEqual(
+            sink.items.count, 1,
+            "a silent return without next() is a dropped chain and must warn: \(sink.items)"
+        )
+        XCTAssertTrue(sink.items.first?.contains("SwallowingMiddleware") ?? false)
+    }
+    #endif
+
+    /// Control: well-behaved middleware calling next() exactly once never warns.
+    func testWellBehavedMiddlewareEmitsNoWarning() async throws {
+        struct PassthroughMiddleware: Middleware {
+            func execute<T: Command>(
+                _ command: T,
+                context: CommandContext,
+                next: @escaping MiddlewareNext<T>
+            ) async throws -> T.Result {
+                try await next(command, context)
+            }
+        }
+        let pipeline = StandardPipeline(handler: EchoHandler())
+        try await pipeline.addMiddleware(PassthroughMiddleware())
+        let result = try await pipeline.execute(TestCommand(value: "ok"), context: CommandContext())
+        XCTAssertEqual(result, "ok")
+        XCTAssertTrue(sink.items.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `swift test --filter "NextGuardErrorExitTests" 2>&1 | tail -20`
+Expected: **compile error** — `markErrorExit` does not exist yet. (After Step 3's NextGuard change alone, `testThrowingMiddlewareWithoutMarkerEmitsNoWarning` would still fail red because the builder doesn't mark yet.)
+
+- [ ] **Step 3: Implement the NextGuard changes**
+
+In `Sources/PipelineKit/Concurrency/Safety/NextGuard.swift`, three edits:
+
+(a) After the `private let suppressDeinitWarning: Bool` property (line 37), add:
+
+```swift
+    #if DEBUG
+    /// Set when the guarded middleware invocation exited by throwing.
+    ///
+    /// An error exit is always caller-visible — never a silently dropped
+    /// chain — so the deinit warning would be noise. The chain builder marks
+    /// the guard before rethrowing. Debug-only: release builds carry no
+    /// deinit diagnostics.
+    private let errorExit = ManagedAtomic<Bool>(false)
+    #endif
+```
+
+(b) After the `execute(_:context:)` compatibility method (ends line 108), add:
+
+```swift
+    /// Records that the middleware invocation guarded by this instance exited
+    /// by throwing, suppressing the debug never-called-next deinit warning.
+    ///
+    /// Called by `MiddlewareChainBuilder` before rethrowing. A throw is always
+    /// observed by the caller, so it can never be the silently-dropped-chain
+    /// bug the warning exists to catch. No-op in release builds.
+    func markErrorExit() {
+        #if DEBUG
+        errorExit.store(true, ordering: .relaxed)
+        #endif
+    }
+```
+
+(c) In `deinit`, immediately after the `if Task.isCancelled { return … }` block (line 119-121), add:
+
+```swift
+            // Error exits are marked by the chain builder and are
+            // caller-visible — never a silent drop
+            if errorExit.load(ordering: .relaxed) {
+                return
+            }
+```
+
+- [ ] **Step 4: Implement the builder changes (both variants)**
+
+In `Sources/PipelineKit/Pipeline/MiddlewareChainBuilder.swift`:
+
+**Variant 1** (ContiguousArray overload) — replace lines 48-61:
+
+```swift
+                    // Create NextGuard lazily, only when middleware will actually execute
+                    let wrappedNext: @Sendable (T, CommandContext) async throws -> T.Result
+                    if isUnsafe {
+                        wrappedNext = previous
+                    } else {
+                        let nextGuard = NextGuard<T>(
+                            previous,
+                            identifier: middlewareName,
+                            suppressDeinitWarning: suppress
+                        )
+                        wrappedNext = nextGuard.callAsFunction
+                    }
+
+                    return try await middleware.execute(cmd, context: ctx, next: wrappedNext)
+```
+
+with:
+
+```swift
+                    // Unsafe middleware opts out of NextGuard entirely
+                    if isUnsafe {
+                        return try await middleware.execute(cmd, context: ctx, next: previous)
+                    }
+
+                    // Create NextGuard lazily, only when middleware will actually execute
+                    let nextGuard = NextGuard<T>(
+                        previous,
+                        identifier: middlewareName,
+                        suppressDeinitWarning: suppress
+                    )
+                    do {
+                        return try await middleware.execute(cmd, context: ctx, next: nextGuard.callAsFunction)
+                    } catch {
+                        // An error exit is caller-visible — never a silently
+                        // dropped chain; keep the debug deinit warning quiet
+                        nextGuard.markErrorExit()
+                        throw error
+                    }
+```
+
+**Variant 2** (Array overload) — replace lines 98-111 (identical code one indentation level shallower):
+
+```swift
+                // Create NextGuard lazily, only when middleware will actually execute
+                let wrappedNext: @Sendable (T, CommandContext) async throws -> T.Result
+                if isUnsafe {
+                    wrappedNext = previous
+                } else {
+                    let nextGuard = NextGuard<T>(
+                        previous,
+                        identifier: middlewareName,
+                        suppressDeinitWarning: suppress
+                    )
+                    wrappedNext = nextGuard.callAsFunction
+                }
+
+                return try await middleware.execute(cmd, context: ctx, next: wrappedNext)
+```
+
+with:
+
+```swift
+                // Unsafe middleware opts out of NextGuard entirely
+                if isUnsafe {
+                    return try await middleware.execute(cmd, context: ctx, next: previous)
+                }
+
+                // Create NextGuard lazily, only when middleware will actually execute
+                let nextGuard = NextGuard<T>(
+                    previous,
+                    identifier: middlewareName,
+                    suppressDeinitWarning: suppress
+                )
+                do {
+                    return try await middleware.execute(cmd, context: ctx, next: nextGuard.callAsFunction)
+                } catch {
+                    // An error exit is caller-visible — never a silently
+                    // dropped chain; keep the debug deinit warning quiet
+                    nextGuard.markErrorExit()
+                    throw error
+                }
+```
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `swift test --filter "NextGuardErrorExitTests" 2>&1 | tail -10`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Regression — module suites + release compile-out**
+
+Run: `swift test --filter "PipelineKitTests\." 2>&1 | tail -5`
+Expected: PASS (covers NextGuardTests, NextGuardIntegrationTests, PipelineChainCacheTests, cancellation suites — all exercise the rebuilt chain closure).
+
+Run: `swift test --filter "PipelineKitCacheTests\." 2>&1 | tail -5`
+Expected: PASS (marker-based suppression path unchanged).
+
+Run: `swift build -c release 2>&1 | tail -3`
+Expected: clean build (proves the `#if DEBUG` members compile out).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/PipelineKit/Concurrency/Safety/NextGuard.swift Sources/PipelineKit/Pipeline/MiddlewareChainBuilder.swift Tests/PipelineKitTests/Safety/NextGuardErrorExitTests.swift
+git commit -m "feat(nextguard): mark error exits in the chain builder to silence false deinit warnings (#97)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Conformance cleanup, pin flips, docs, changelog
+
+**Files:**
+- Modify (remove `, NextGuardWarningSuppressing` from the type declaration line):
+  - `Sources/PipelineKitResilienceRateLimiting/RateLimitingMiddleware.swift:14`
+  - `Sources/PipelineKitResilienceRateLimiting/EnhancedRateLimitingMiddleware.swift:28`
+  - `Sources/PipelineKitResilienceCore/BackPressureMiddleware.swift:7`
+  - `Sources/PipelineKitSecurity/Middleware/Authorization/AuthorizationMiddleware.swift:9`
+  - `Sources/PipelineKitSecurity/Middleware/Validation/ValidationMiddleware.swift:24`
+  - `Sources/PipelineKitSecurity/Middleware/Authentication/AuthenticationMiddleware.swift:66`
+  - `Sources/PipelineKitSecurity/Policies/SecurityPolicy.swift:72`
+  - `Sources/PipelineKitTestSupport/Mocks/MockTypes.swift:35`
+  - `Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift:33`
+  - `Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift:60`
+  - `Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift:34`
+  - `Sources/PipelineKitResilienceCircuitBreaker/HealthCheckMiddleware.swift:33`
+  - `Examples/Sources/AdvancedExample/main.swift:44`
+- Modify (stale doc comments): `AuthorizationMiddleware.swift:6-8`, `AuthenticationMiddleware.swift:63-65`
+- Modify: `Sources/PipelineKitCore/Middleware/Middleware.swift:225-230` (protocol doc)
+- Modify: `Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift` (full replacement below)
+- Modify: `Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift` (full replacement below)
+- Modify: `Tests/PipelineKitCacheTests/NextGuardSuppressionTests.swift` (add one pin test)
+- Modify: `CHANGELOG.md` (`[Unreleased]` section + link ref)
+
+**Interfaces:**
+- Consumes: Task 1's builder-level `markErrorExit()` marking — the reason the removals are safe.
+- Produces: nothing later tasks rely on (final task).
+
+**DO NOT touch** the four cache conformances (`CachingMiddleware.swift:51`, `SimpleCachingMiddleware.swift:64`, `CachedMiddleware.swift:8`, `CachedMiddleware.swift:224`) or any test-local helper conformances under `Tests/` other than the three test files listed.
+
+- [ ] **Step 1: Flip the resilience pin test (failing first)**
+
+Replace the entire contents of `Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift` with:
+
+```swift
+//
+//  NextGuardSuppressionConformanceTests.swift
+//  PipelineKit
+//
+//  Pins the #97 re-arm: throw-based short-circuiting middleware must NOT
+//  conform to NextGuardWarningSuppressing. The chain builder detects error
+//  exits itself since 0.6, and conforming would disarm the debug diagnostic
+//  that catches a genuinely dropped chain (a silent return without next()).
+//
+
+import XCTest
+import PipelineKitCore
+import PipelineKitResilience
+
+final class NextGuardSuppressionConformanceTests: XCTestCase {
+    func testThrowBasedResilienceMiddlewaresDoNotSuppressNextGuardWarnings() {
+        XCTAssertFalse(BackPressureMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(CircuitBreakerMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(RateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(EnhancedRateLimitingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(BulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(PartitionedBulkheadMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(HealthCheckMiddleware.self is any NextGuardWarningSuppressing.Type)
+    }
+}
+```
+
+Replace the entire contents of `Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift` with:
+
+```swift
+//
+//  NextGuardSuppressionConformanceTests.swift
+//  PipelineKit
+//
+//  Pins the #97 re-arm for security middleware: these types short-circuit
+//  only by throwing, which the chain builder detects since 0.6.
+//
+
+import XCTest
+import PipelineKitCore
+import PipelineKitSecurity
+
+final class NextGuardSuppressionConformanceTests: XCTestCase {
+    func testThrowBasedSecurityMiddlewaresDoNotSuppressNextGuardWarnings() {
+        XCTAssertFalse(ValidationMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(SecurityPolicyMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(AuthenticationMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertFalse(AuthorizationMiddleware.self is any NextGuardWarningSuppressing.Type)
+    }
+}
+```
+
+In `Tests/PipelineKitCacheTests/NextGuardSuppressionTests.swift`, add this test method inside the class (after `testCachingMiddlewareSuppressesNextGuardWarningOnCacheHit`):
+
+```swift
+    /// Pins that the cache middlewares KEEP NextGuardWarningSuppressing (#97):
+    /// they return a result without calling next() on a cache hit — the one
+    /// legitimate use of the marker after the chain builder learned to detect
+    /// error exits on its own.
+    func testCacheMiddlewaresRetainNextGuardSuppression() {
+        XCTAssertTrue(CachingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(SimpleCachingMiddleware.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(CachedMiddleware<CachingMiddleware>.self is any NextGuardWarningSuppressing.Type)
+        XCTAssertTrue(ConditionalCachedMiddleware<CachingMiddleware>.self is any NextGuardWarningSuppressing.Type)
+    }
+```
+
+- [ ] **Step 2: Run the flipped pins to verify they fail**
+
+Run: `swift test --filter "NextGuardSuppressionConformanceTests" 2>&1 | tail -10`
+Expected: FAIL — the `XCTAssertFalse` assertions fail because the conformances still exist. (The cache pin passes already; that is fine — it is a keep-pin.)
+
+- [ ] **Step 3: Remove the 13 conformances and the two stale doc comments**
+
+For each of the 13 declaration lines listed under **Files**, delete only the text `, NextGuardWarningSuppressing` from the declaration. Examples of the edit shape:
+
+`CircuitBreakerMiddleware.swift:33`:
+```swift
+public struct CircuitBreakerMiddleware: Middleware, NextGuardWarningSuppressing {
+```
+becomes
+```swift
+public struct CircuitBreakerMiddleware: Middleware {
+```
+
+`BackPressureMiddleware.swift:7` (actor):
+```swift
+public actor BackPressureMiddleware: Middleware, NextGuardWarningSuppressing {
+```
+becomes
+```swift
+public actor BackPressureMiddleware: Middleware {
+```
+
+In `AuthorizationMiddleware.swift`, also delete these three doc-comment lines (6-8), leaving the summary line and its trailing `///` separator intact:
+```swift
+/// This middleware conforms to `NextGuardWarningSuppressing` because it
+/// intentionally short-circuits the pipeline by throwing when authorization fails,
+/// without calling `next()`. This is expected behavior for security middleware.
+```
+
+In `AuthenticationMiddleware.swift`, also delete these three doc-comment lines (63-65):
+```swift
+/// AuthenticationMiddleware conforms to NextGuardWarningSuppressing because it
+/// intentionally short-circuits the pipeline by throwing when authentication fails,
+/// without calling `next()`. This is expected behavior for security middleware.
+```
+
+- [ ] **Step 4: Narrow the protocol doc comment**
+
+In `Sources/PipelineKitCore/Middleware/Middleware.swift`, replace lines 225-230:
+
+```swift
+/// A marker protocol for middleware that want to suppress NextGuard deinit warnings.
+///
+/// Conform when middleware may intentionally not call `next` under normal,
+/// non-error conditions and the lack of a call should not surface as a debug warning
+/// (for example, caching or fast-path short-circuiting). This affects only debug
+/// deinit warnings; it does not change NextGuard's runtime safety checks.
+```
+
+with:
+
+```swift
+/// A marker protocol for middleware that want to suppress NextGuard deinit warnings.
+///
+/// Conform only when middleware may intentionally RETURN a result without
+/// calling `next` on a normal, non-error path (for example, serving a cache
+/// hit). Middleware that short-circuits by THROWING does not need this: the
+/// chain builder detects error exits and suppresses the debug warning
+/// automatically — a throw is always caller-visible, so conforming a
+/// throw-based middleware only disarms the diagnostic that catches a
+/// genuinely dropped chain. This affects only debug deinit warnings; it does
+/// not change NextGuard's runtime safety checks.
+```
+
+- [ ] **Step 5: Update CHANGELOG**
+
+In `CHANGELOG.md`, replace the empty `## [Unreleased]` section (currently just the heading, directly above `## [0.5.4] - 2026-08-15`) with:
+
+```markdown
+## [Unreleased]
+
+### Changed
+- `NextGuard` debug diagnostics are now error-exit aware: middleware that
+  throws without calling `next()` no longer emits the false "deallocated
+  without calling next()" warning — the middleware chain now marks the guard
+  before rethrowing. `NextGuardWarningSuppressing` is only needed for
+  middleware that *returns* a result without calling `next()` on a normal
+  path (e.g. cache hits). Debug-only; release builds are unchanged. ([#97])
+
+### Removed
+- `NextGuardWarningSuppressing` conformance removed from the twelve
+  throw-based short-circuiting middlewares (`BackPressureMiddleware`,
+  `CircuitBreakerMiddleware`, `RateLimitingMiddleware`,
+  `EnhancedRateLimitingMiddleware`, `BulkheadMiddleware`,
+  `PartitionedBulkheadMiddleware`, `HealthCheckMiddleware`,
+  `ValidationMiddleware`, `SecurityPolicyMiddleware`,
+  `AuthenticationMiddleware`, `AuthorizationMiddleware`,
+  `MockAuthenticationMiddleware`), re-arming the dropped-chain diagnostic
+  for those types. Observable only to code checking
+  `is any NextGuardWarningSuppressing`; the cache middlewares keep the
+  conformance. ([#97])
+```
+
+At the bottom of the file, in the link-reference block, add (alphabetically/numerically with the existing `[#86]`/`[#92]` refs):
+
+```markdown
+[#97]: https://github.com/gifton/PipelineKit/issues/97
+```
+
+- [ ] **Step 6: Run the pins and affected suites to verify green**
+
+Run: `swift test --filter "NextGuardSuppressionConformanceTests" 2>&1 | tail -5`
+Expected: PASS (all assertFalse now hold).
+
+Run: `swift test --filter "PipelineKitCacheTests\." 2>&1 | tail -5`
+Expected: PASS.
+
+Run: `swift test --filter "PipelineKitSecurityTests\." 2>&1 | tail -5`
+Expected: PASS.
+
+Run: `swift test --filter "PipelineKitResilienceTests\." 2>&1 | tail -5`
+Expected: PASS (the timeout/cancellation suites keep their own test-local markers; behavior unchanged).
+
+Run: `swift build --package-path Examples 2>&1 | tail -3`
+Expected: clean build (verifies the example edit).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources Examples Tests CHANGELOG.md
+git commit -m "refactor(nextguard): remove warning-suppression conformance from throw-based middleware (#97)
+
+The chain builder now detects error exits itself; the marker is only for
+return-based short-circuits (cache hits). Re-arms the dropped-chain debug
+diagnostic for twelve middlewares.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/plans/2026-08-15-nextguard-throw-aware-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-15-nextguard-throw-aware-diagnostics.md
@@ -349,7 +349,7 @@ with:
 - [ ] **Step 5: Run the new tests to verify they pass**
 
 Run: `swift test --filter "NextGuardErrorExitTests" 2>&1 | tail -10`
-Expected: PASS (6 tests).
+Expected: PASS (5 tests).
 
 - [ ] **Step 6: Regression — module suites + release compile-out**
 

--- a/docs/superpowers/specs/2026-08-15-nextguard-throw-aware-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-15-nextguard-throw-aware-diagnostics-design.md
@@ -1,0 +1,165 @@
+# Throw-Aware NextGuard Deinit Diagnostics — Design
+
+**Date:** 2026-08-15
+**Issue:** [#97](https://github.com/gifton/PipelineKit/issues/97)
+**Target release:** 0.6 (conformance removals are minor-level per VERSIONING.md)
+
+## Problem
+
+`NextGuard`'s debug-only deinit warning ("deallocated without calling next()") exists to
+catch exactly one bug class: middleware that returns **successfully** without invoking
+downstream — a silently dropped chain. A **throw** is never a silent drop: the caller
+always observes the error. But Swift `deinit` has no unwind context, so the guard cannot
+distinguish "middleware threw deliberately" from "middleware silently returned".
+
+0.5.4 addressed the resulting false positives by conforming nine throw-based
+rejection-path middlewares to `NextGuardWarningSuppressing` (type-level suppression,
+matching the pre-existing cache/auth precedent). That was patch-appropriate but coarser
+than the information available, and it disarms the diagnostic for the *genuine* bug class
+on those types: a future path that returns without `next` and without throwing goes
+unflagged.
+
+The one component that *can* see the throw is `MiddlewareChainBuilder` — it invokes
+`middleware.execute(...)` with the guard in scope.
+
+## Design decisions
+
+### D1 — `NextGuard` gains debug-only error-exit tracking
+
+`Sources/PipelineKit/Concurrency/Safety/NextGuard.swift`:
+
+- New `#if DEBUG` stored property: `private let errorExit = ManagedAtomic<Bool>(false)`.
+- New **internal** method `markErrorExit()` — always declared (callers compile in both
+  configs), body is `#if DEBUG`-gated so it is a no-op that inlines to nothing in release.
+- `deinit` (already `#if DEBUG`) early-returns when `errorExit` is set, alongside the
+  existing `Task.isCancelled` and `suppressDeinitWarning` checks. The `Task.isCancelled`
+  heuristic is **retained** (belt-and-suspenders for guards deinited off the error path).
+
+`NextGuard` and `MiddlewareChainBuilder` are both in the `PipelineKit` module, so the
+method is `internal`: **zero new public API**. Third parties constructing `NextGuard`
+via its public init keep exactly today's behavior.
+
+### D2 — `MiddlewareChainBuilder` marks error exits
+
+`Sources/PipelineKit/Pipeline/MiddlewareChainBuilder.swift`, **both** build variants
+(`ContiguousArray` at ~line 48-61 and `Array` at ~line 98-111): restructure the guarded
+branch so the guard stays in scope, and wrap the middleware invocation:
+
+```swift
+// Unsafe middleware opts out of NextGuard entirely
+if isUnsafe {
+    return try await middleware.execute(cmd, context: ctx, next: previous)
+}
+
+// Create NextGuard lazily, only when middleware will actually execute
+let nextGuard = NextGuard<T>(
+    previous,
+    identifier: middlewareName,
+    suppressDeinitWarning: suppress
+)
+do {
+    return try await middleware.execute(cmd, context: ctx, next: nextGuard.callAsFunction)
+} catch {
+    // An error exit is caller-visible — never a silently dropped chain
+    nextGuard.markErrorExit()
+    throw error
+}
+```
+
+Success path is logically untouched. Error-path cost: one branch + one relaxed atomic
+store (debug only). Swift error handling is error-return, not unwinding, so the `do/catch`
+adds nothing to the success path. The `suppress` flag and `isUnsafe` opt-out are retained
+unchanged.
+
+### D3 — Conformance cleanup: marker only for return-based short-circuits
+
+**Remove `NextGuardWarningSuppressing`** from the 12 production types that short-circuit
+exclusively by throwing (verified per-type by reading every `execute` body), plus one
+example type:
+
+| # | Type | File |
+|---|------|------|
+| 1 | `RateLimitingMiddleware` | `Sources/PipelineKitResilienceRateLimiting/RateLimitingMiddleware.swift:14` |
+| 2 | `EnhancedRateLimitingMiddleware` | `Sources/PipelineKitResilienceRateLimiting/EnhancedRateLimitingMiddleware.swift:28` |
+| 3 | `BackPressureMiddleware` | `Sources/PipelineKitResilienceCore/BackPressureMiddleware.swift:7` |
+| 4 | `AuthorizationMiddleware` | `Sources/PipelineKitSecurity/Middleware/Authorization/AuthorizationMiddleware.swift:9` (+ stale doc comment above) |
+| 5 | `ValidationMiddleware` | `Sources/PipelineKitSecurity/Middleware/Validation/ValidationMiddleware.swift:24` |
+| 6 | `AuthenticationMiddleware` | `Sources/PipelineKitSecurity/Middleware/Authentication/AuthenticationMiddleware.swift:66` (+ stale doc comment above) |
+| 7 | `SecurityPolicyMiddleware` | `Sources/PipelineKitSecurity/Policies/SecurityPolicy.swift:72` |
+| 8 | `MockAuthenticationMiddleware` | `Sources/PipelineKitTestSupport/Mocks/MockTypes.swift:35` |
+| 9 | `CircuitBreakerMiddleware` | `Sources/PipelineKitResilienceCircuitBreaker/CircuitBreakerMiddleware.swift:33` |
+| 10 | `BulkheadMiddleware` | `Sources/PipelineKitResilienceCircuitBreaker/BulkheadMiddleware.swift:60` |
+| 11 | `PartitionedBulkheadMiddleware` | `Sources/PipelineKitResilienceCircuitBreaker/PartitionedBulkheadMiddleware.swift:34` |
+| 12 | `HealthCheckMiddleware` | `Sources/PipelineKitResilienceCircuitBreaker/HealthCheckMiddleware.swift:33` |
+| 13 | `OrderValidationMiddleware` (example) | `Examples/Sources/AdvancedExample/main.swift:44` |
+
+**Keep the marker** on the four cache middlewares — they genuinely return a result
+without calling `next` on a cache hit (verified):
+
+- `CachingMiddleware` (`Sources/PipelineKitCache/CachingMiddleware.swift:51`)
+- `SimpleCachingMiddleware` (`Sources/PipelineKitCache/SimpleCachingMiddleware.swift:64`)
+- `CachedMiddleware` (`Sources/PipelineKitCache/CachedMiddleware.swift:8`)
+- `ConditionalCachedMiddleware` (`Sources/PipelineKitCache/CachedMiddleware.swift:224`)
+
+### D4 — Test strategy
+
+1. **New unit + chain tests** in `Tests/PipelineKitTests/Safety/NextGuardErrorExitTests.swift`
+   (`@testable import PipelineKit` is house-normal in that directory):
+   - Unit: `markErrorExit()` then release → no warning; uncalled + unmarked release → warning.
+   - Chain: a **non-conforming** throwing middleware through `StandardPipeline` → no
+     warning (this is the red test pre-implementation).
+   - Chain re-arm control: a **non-conforming** middleware that silently returns without
+     `next` → warning IS emitted (the diagnostic the cleanup re-arms).
+2. **Release-config compatibility (hard constraint):** the release workflow runs the
+   suite with `-c release`, where the `#if DEBUG` deinit does not exist. Every test that
+   asserts a warning **is** emitted must be wrapped in `#if DEBUG` in the test file, or
+   the v0.6.0 tag build breaks. No-warning assertions are vacuous-but-safe in release.
+3. **Capture pattern:** synchronous lock-based sink (`NSLock`) installed via
+   `NextGuardConfiguration.setWarningHandler`, restored in `tearDown`
+   (`warningHandler = nil`, `emitWarnings = true`). Do NOT copy the existing
+   `Tests/PipelineKitCacheTests/NextGuardSuppressionTests.swift` pattern verbatim: its
+   async `Task { await collector.add… }` hop can race the snapshot, and it never restores
+   the handler. Guard deinit is synchronous before `pipeline.execute` returns, so a
+   synchronous sink needs no waiting.
+4. **Pin-test flips:** the two conformance-pin files
+   (`Tests/PipelineKitResilienceTests/NextGuardSuppressionConformanceTests.swift`,
+   `Tests/PipelineKitSecurityTests/NextGuardSuppressionConformanceTests.swift`) flip
+   `XCTAssertTrue` → `XCTAssertFalse` (pinning the re-arm), with Authentication and
+   Authorization added to the security file. A new pin asserting the four cache types
+   still conform is added to `Tests/PipelineKitCacheTests/NextGuardSuppressionTests.swift`.
+
+### D5 — Docs & changelog
+
+- Narrow the `NextGuardWarningSuppressing` doc comment
+  (`Sources/PipelineKitCore/Middleware/Middleware.swift:225-233`): conform **only** for
+  return-without-next normal paths (cache hits); throw-based short-circuits are detected
+  automatically by the chain builder since 0.6.
+- `CHANGELOG.md` `[Unreleased]`: `### Changed` (error-exit-aware diagnostics, [#97]) and
+  `### Removed` (the conformance list, [#97]). Add the `[#97]` link reference.
+
+## Behavioral contract (after this change)
+
+| Scenario (debug builds) | Before | After |
+|---|---|---|
+| Middleware throws without calling `next` | warns unless type conforms | never warns (any middleware) |
+| Middleware returns without calling `next` | warns unless type conforms | warns unless type conforms |
+| The 12 de-conformed types silently return without `next` | **silent** (disarmed) | **warns** (re-armed) |
+| `next` called exactly once | no warning | no warning |
+| Double/concurrent `next` call | throws (runtime check) | unchanged |
+| Release builds | no diagnostics | unchanged (method compiles to no-op) |
+
+## Non-goals
+
+- **Test-local helper conformances** (SlowMiddleware etc. in `Tests/`): now mostly
+  redundant (cancellation propagates as a throw and is builder-marked) but harmless;
+  cleaning ~12 of them up is out of scope.
+- **Making `markErrorExit()` public** for third-party pipeline builders — hold until asked.
+- **Retiring the `Task.isCancelled` deinit heuristic** — retained as a backstop.
+- **Synchronizing `NextGuardConfiguration`** — separate audit finding, unchanged here.
+
+## Versioning
+
+Removing a public protocol conformance is source-visible only to
+`is any NextGuardWarningSuppressing` checks (in practice: only our own pin tests).
+Per VERSIONING.md this is **0.6 minor** material; the next tag from main after this
+merges must be v0.6.0. Release-build behavior is byte-for-byte equivalent.

--- a/docs/tutorials/custom-middleware.md
+++ b/docs/tutorials/custom-middleware.md
@@ -134,4 +134,4 @@ let conditional = ConditionalCachedMiddleware(
 
 ## Notes
 - Use `ExecutionPriority` to place middleware correctly; equal priorities preserve insertion order.
-- For middleware that intentionally short‑circuits without calling `next()` (e.g., cache hits), conform to `NextGuardWarningSuppressing` to suppress debug‑only deinit warnings.
+- For middleware that intentionally RETURNS a result without calling `next()` on a normal path (e.g., cache hits), conform to `NextGuardWarningSuppressing` to suppress debug‑only deinit warnings. Since 0.6, throw‑based short‑circuits (rejections, validation failures, timeouts/cancellation) are detected automatically by the middleware chain and don't need this.


### PR DESCRIPTION
Closes #97. Targets **0.6** (contains conformance removals — the next tag from main after this merges should be v0.6.0, not a 0.5.x patch).

## What

0.5.4 silenced false "NextGuard deallocated without calling next()" debug warnings on nine rejection-path middlewares via type-level `NextGuardWarningSuppressing` conformance. That was patch-appropriate but coarser than the information available: it also disarmed the diagnostic for the one bug class the warning exists to catch (a *silent return* without calling `next()` — a dropped chain). This PR moves the detection to where the information lives:

1. **`NextGuard` is now error-exit aware** (`feat`, f13ba49): a `#if DEBUG` atomic flag + internal `markErrorExit()`; `MiddlewareChainBuilder`'s two build variants wrap the middleware invocation in `do/catch` and mark the guard before rethrowing. A throw is always caller-visible, so it never warns — for *any* middleware, no conformance needed. **Zero new public API** (guard and builder share the `PipelineKit` module); release builds are behaviorally identical (the flag, the mark, and the deinit check all compile out).
2. **Conformance cleanup** (`refactor`, 738f411): `NextGuardWarningSuppressing` removed from the 12 throw-only production types (BackPressure, CircuitBreaker, RateLimiting, EnhancedRateLimiting, Bulkhead, PartitionedBulkhead, HealthCheck, Validation, SecurityPolicy, Authentication, Authorization, MockAuthentication) + the AdvancedExample middleware — **re-arming** the dropped-chain diagnostic for them. The four cache middlewares keep the marker (genuine return-without-next on cache hits). Conformance pins flipped to `XCTAssertFalse` + a keep-pin added for the cache four.
3. **Docs narrowed** (`docs`, 49e0dc2): protocol doc comment, README ×2, architecture/performance guides, custom-middleware tutorial, and both internal NextGuard docs now teach the narrowed contract (marker = return-without-next only; throws auto-detected since 0.6).

## Diagnostic contract after this PR (debug builds)

| Scenario | Before | After |
|---|---|---|
| Middleware throws without calling `next()` | warns unless type conforms | never warns |
| Middleware silently returns without `next()` | warns unless type conforms | warns unless type conforms |
| The 12 de-conformed types silently return | **silent** (disarmed) | **warns** (re-armed) |
| Double/concurrent `next()` call | runtime error | unchanged |
| Release builds | no diagnostics | unchanged |

## Testing

- New `NextGuardErrorExitTests` (5 tests): unit-level mark semantics, chain-level throw→no-warning, silent-return→warning (the re-arm control), well-behaved control. Warning-asserting tests are `#if DEBUG`-gated so `swift test -c release` (release workflow + sanitizer lanes) stays green — verified empirically: release-config run executes 3 tests with the gated pair compiled out.
- TDD both tasks (red runs recorded in the SDD reports); filtered suites green: PipelineKitTests 167, Resilience 141, Security 110 (incl. new MockAuthenticationMiddleware pin), Cache 34; Examples package builds.
- Perf sanity (release, M3 Max): ~1.37µs/cmd simple pipeline, ~0.18µs/middleware — matches the audit baseline (~1.5µs / ~0.19µs); success path untouched by design (the `do/catch` costs one branch on the error path only).
- Whole-branch review (independent): guard lifetime through the restructured closure verified (mark ordered before final release; cross-thread deinit observes it via the refcount runtime's acquire on final decrement), both builder variants token-identical, no other `NextGuard` construction sites in Sources, all 12 de-conformed types re-verified as throw-only.

## Notes for review

- `docs/internal/NEXTGUARD_TIMEOUT_LIMITATION.md` has been fully rewritten (a93a713) as resolved design history: the pre-0.6 limitation, the 0.6 error-exit resolution, and the remaining `Task.isCancelled` backstop.
- Spec + plan live at `docs/superpowers/{specs,plans}/2026-08-15-nextguard-throw-aware-diagnostics*`.

Maintainer gate: full unfiltered suite in Xcode before merge, per house process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
